### PR TITLE
Normalize user file path resolution in login window

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -8,7 +8,10 @@ import os
 from ui.admin_dashboard import AdminDashboard
 from ui.owner_dashboard import OwnerDashboard
 
-USER_FILE = os.path.join(os.path.dirname(__file__), "../data/users.txt")
+# Determine the path to the users file in a cross-platform way
+USER_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "data", "users.txt")
+)
 
 class LoginWindow(QWidget):
     def __init__(self):


### PR DESCRIPTION
## Summary
- ensure login window uses cross-platform path to users.txt via os.path.abspath and os.path.join

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896186e9780832ea50ad9072af06e8c