### PR TITLE
Handle numeric is_pitcher flag and add pitcher CSV test

### DIFF
--- a/tests/test_player_loader.py
+++ b/tests/test_player_loader.py
@@ -1,5 +1,6 @@
 import csv
 import pytest
+from models.pitcher import Pitcher
 from utils.player_loader import load_players_from_csv
 
 
@@ -108,3 +109,66 @@ def test_missing_required_numeric_field_raises(tmp_path):
         )
     with pytest.raises(ValueError):
         load_players_from_csv(file_path)
+
+
+def test_load_pitcher_with_numeric_flag(tmp_path):
+    file_path = tmp_path / "players.csv"
+    fieldnames = [
+        "player_id",
+        "first_name",
+        "last_name",
+        "birthdate",
+        "height",
+        "weight",
+        "bats",
+        "primary_position",
+        "gf",
+        "is_pitcher",
+        "endurance",
+        "control",
+        "hold_runner",
+        "fb",
+        "cu",
+        "cb",
+        "sl",
+        "si",
+        "scb",
+        "kn",
+        "arm",
+        "fa",
+    ]
+    with open(file_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "player_id": "1",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "birthdate": "1990-01-01",
+                "height": "70",
+                "weight": "175",
+                "bats": "R",
+                "primary_position": "P",
+                "gf": "40",
+                "is_pitcher": "1",
+                "endurance": "80",
+                "control": "75",
+                "hold_runner": "60",
+                "fb": "65",
+                "cu": "60",
+                "cb": "55",
+                "sl": "50",
+                "si": "45",
+                "scb": "40",
+                "kn": "35",
+                "arm": "85",
+                "fa": "90",
+            }
+        )
+    players = load_players_from_csv(file_path)
+    assert len(players) == 1
+    player = players[0]
+    assert isinstance(player, Pitcher)
+    assert player.endurance == 80
+    assert player.control == 75

--- a/utils/player_loader.py
+++ b/utils/player_loader.py
@@ -22,7 +22,8 @@ def load_players_from_csv(file_path):
     with open(file_path, mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            is_pitcher = row.get("is_pitcher", "").lower() == "true"
+            is_pitcher_value = row.get("is_pitcher", "").lower()
+            is_pitcher = is_pitcher_value in ("true", "1")
 
             height = _required_int(row, "height")
             weight = _required_int(row, "weight")


### PR DESCRIPTION
## Summary
- allow `load_players_from_csv` to treat `is_pitcher` values of "1" as pitchers
- test loading a pitcher when CSV uses numeric flag and ensure endurance and control preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964cbf3d34832eb8aef5659e78e54a