### PR TITLE
Write numeric flag for pitchers when saving CSV

### DIFF
--- a/tests/test_player_writer.py
+++ b/tests/test_player_writer.py
@@ -1,0 +1,39 @@
+import csv
+from models.player import Player
+from models.pitcher import Pitcher
+from utils.player_writer import save_players_to_csv
+
+
+def test_save_players_to_csv_marks_pitchers(tmp_path):
+    file_path = tmp_path / "players.csv"
+    pitcher = Pitcher(
+        player_id="p1",
+        first_name="Pitch",
+        last_name="Er",
+        birthdate="1990-01-01",
+        height=72,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=10,
+    )
+    hitter = Player(
+        player_id="h1",
+        first_name="Hit",
+        last_name="Ter",
+        birthdate="1991-02-02",
+        height=70,
+        weight=175,
+        bats="L",
+        primary_position="1B",
+        other_positions=[],
+        gf=20,
+    )
+    save_players_to_csv([pitcher, hitter], file_path)
+    with open(file_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    rows_by_id = {row["player_id"]: row["is_pitcher"] for row in rows}
+    assert rows_by_id["p1"] == "1"
+    assert rows_by_id["h1"] == "0"

--- a/utils/player_writer.py
+++ b/utils/player_writer.py
@@ -31,7 +31,7 @@ def save_players_to_csv(players, file_path):
                 "bats": p.bats,
                 "primary_position": p.primary_position,
                 "other_positions": "|".join(p.other_positions),
-                "is_pitcher": str(is_pitcher),
+                "is_pitcher": "1" if is_pitcher else "0",
                 "injured": str(p.injured),
                 "injury_description": p.injury_description or "",
                 "return_date": p.return_date or ""


### PR DESCRIPTION
## Summary
- ensure `is_pitcher` uses "1"/"0" when writing player CSV rows
- test saving players writes "1" for pitchers and "0" for hitters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965547bdd8832e980359ac9dd147f8