### PR TITLE
Add admin league creation with roster generation

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -3,16 +3,20 @@ import random
 import uuid
 from datetime import datetime, timedelta
 from typing import Dict, List
-import pandas as pd
+# pandas is optional; fall back to simple names if unavailable
+try:
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - handled by fallback
+    pd = None
 import os
 
 # Constants
 base_dir = os.path.dirname(os.path.abspath(__file__))
 NAME_PATH = os.path.join(base_dir, "..", "data", "names.csv")
-if os.path.exists(NAME_PATH):
+if pd is not None and os.path.exists(NAME_PATH):
     name_df = pd.read_csv(NAME_PATH)
     grouped_names = name_df.groupby("ethnicity")
-else:
+else:  # pragma: no cover - fallback when pandas or file missing
     grouped_names = None
 
     

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -1,0 +1,31 @@
+import csv
+import os
+from logic.league_creator import create_league
+
+
+def test_create_league_generates_files(tmp_path):
+    divisions = {"East": [("CityA", "Cats"), ("CityB", "Dogs")]}
+    create_league(str(tmp_path), divisions, roster_size=10)
+
+    teams_path = tmp_path / "teams.csv"
+    players_path = tmp_path / "players.csv"
+    rosters_dir = tmp_path / "rosters"
+
+    assert teams_path.exists()
+    assert players_path.exists()
+    assert rosters_dir.is_dir()
+
+    with open(teams_path, newline="") as f:
+        teams = list(csv.DictReader(f))
+    assert len(teams) == 2
+
+    with open(players_path, newline="") as f:
+        players = list(csv.DictReader(f))
+    assert len(players) == 20
+
+    for t in teams:
+        r_file = rosters_dir / f"{t['team_id']}.csv"
+        assert r_file.exists()
+        with open(r_file) as f:
+            lines = [line for line in f.read().strip().splitlines() if line]
+        assert len(lines) == 10


### PR DESCRIPTION
## Summary
- allow admin to create leagues and configure divisions/teams from dashboard
- generate team files, rosters, and players via player generation model
- make player generation work without pandas dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896668a3cd0832ebd42bb8480229d66