### PR TITLE
Fix pitcher arm strength display in roster viewer

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -36,6 +36,8 @@ def _dict_to_model(data: dict):
         return_date=data.get("return_date"),
     )
     if data.get("is_pitcher"):
+        arm = data.get("arm") or data.get("fb", 0)
+        potentials.setdefault("arm", arm)
         return Pitcher(
             **common,
             endurance=data.get("endurance", 0),
@@ -48,7 +50,7 @@ def _dict_to_model(data: dict):
             si=data.get("si", 0),
             scb=data.get("scb", 0),
             kn=data.get("kn", 0),
-            arm=data.get("arm", 0),
+            arm=arm,
             fa=data.get("fa", 0),
             potential=potentials,
         )

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -1,6 +1,7 @@
 import csv
 import os
-from logic.league_creator import create_league
+from logic.league_creator import create_league, _dict_to_model
+from models.pitcher import Pitcher
 
 
 def test_create_league_generates_files(tmp_path):
@@ -29,3 +30,33 @@ def test_create_league_generates_files(tmp_path):
         with open(r_file) as f:
             lines = [line for line in f.read().strip().splitlines() if line]
         assert len(lines) == 10
+
+
+def test_dict_to_model_defaults_pitcher_arm_to_fastball():
+    data = {
+        "player_id": "p1",
+        "first_name": "Pitch",
+        "last_name": "Er",
+        "birthdate": "1990-01-01",
+        "height": 72,
+        "weight": 180,
+        "bats": "R",
+        "primary_position": "P",
+        "other_positions": "",
+        "gf": 5,
+        "is_pitcher": True,
+        "endurance": 50,
+        "control": 60,
+        "hold_runner": 40,
+        "fb": 70,
+        "cu": 60,
+        "cb": 50,
+        "sl": 55,
+        "si": 45,
+        "scb": 65,
+        "kn": 40,
+    }
+    pitcher = _dict_to_model(data)
+    assert isinstance(pitcher, Pitcher)
+    assert pitcher.arm == 70
+    assert pitcher.potential["arm"] == 70

--- a/tests/test_player_loader.py
+++ b/tests/test_player_loader.py
@@ -58,6 +58,7 @@ def test_load_player_with_optional_columns_missing(tmp_path):
     assert player.injury_description is None
     assert player.potential["ch"] == 60
     assert player.potential["gf"] == 50
+    assert player.arm == 90
 
 
 def test_missing_required_numeric_field_raises(tmp_path):
@@ -168,3 +169,64 @@ def test_numeric_is_pitcher_creates_pitcher(tmp_path):
     player = players[0]
     assert isinstance(player, Pitcher)
     assert player.endurance > 0 and player.control > 0
+    assert player.arm == 60
+
+
+def test_pitcher_arm_defaults_to_fastball(tmp_path):
+    file_path = tmp_path / "players.csv"
+    fieldnames = [
+        "player_id",
+        "first_name",
+        "last_name",
+        "birthdate",
+        "height",
+        "weight",
+        "bats",
+        "primary_position",
+        "gf",
+        "is_pitcher",
+        "endurance",
+        "control",
+        "hold_runner",
+        "fb",
+        "cu",
+        "cb",
+        "sl",
+        "si",
+        "scb",
+        "kn",
+        "arm",
+    ]
+    with open(file_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "player_id": "3",
+                "first_name": "Pitch",
+                "last_name": "Tester",
+                "birthdate": "1991-01-01",
+                "height": "72",
+                "weight": "180",
+                "bats": "R",
+                "primary_position": "SP",
+                "gf": "5",
+                "is_pitcher": "1",
+                "endurance": "50",
+                "control": "60",
+                "hold_runner": "40",
+                "fb": "70",
+                "cu": "60",
+                "cb": "50",
+                "sl": "55",
+                "si": "45",
+                "scb": "65",
+                "kn": "40",
+                "arm": "0",
+            }
+        )
+    players = load_players_from_csv(file_path)
+    assert len(players) == 1
+    player = players[0]
+    assert isinstance(player, Pitcher)
+    assert player.arm == 70

--- a/tests/test_player_writer.py
+++ b/tests/test_player_writer.py
@@ -17,6 +17,7 @@ def test_save_players_to_csv_marks_pitchers(tmp_path):
         primary_position="P",
         other_positions=[],
         gf=10,
+        arm=50,
     )
     hitter = Player(
         player_id="h1",
@@ -29,6 +30,7 @@ def test_save_players_to_csv_marks_pitchers(tmp_path):
         primary_position="1B",
         other_positions=[],
         gf=20,
+        arm=60,
     )
     save_players_to_csv([pitcher, hitter], file_path)
     with open(file_path, newline="") as f:

--- a/utils/player_loader.py
+++ b/utils/player_loader.py
@@ -57,6 +57,8 @@ def load_players_from_csv(file_path):
                 scb = _required_int(row, "scb")
                 kn = _required_int(row, "kn")
                 arm = _optional_int(row, "arm")
+                if arm == 0:
+                    arm = fb
                 fa = _optional_int(row, "fa")
                 player = Pitcher(
                     **common_kwargs,


### PR DESCRIPTION
## Summary
- Default pitcher arm rating to fastball when missing across league creation
- Cover loader and league creator paths with tests to ensure every player has an arm rating
- Update writer test to construct players with arm ratings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896d92404f4832e875167d33f9fce10