### PR TITLE
Style admin dashboard and add league overwrite warning

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -20,6 +20,7 @@ def _abbr(city: str, name: str, existing: set) -> str:
 
 def _dict_to_model(data: dict):
     potentials = {k[4:]: v for k, v in data.items() if k.startswith("pot_")}
+    other_pos = data.get("other_positions")
     common = dict(
         player_id=data.get("player_id"),
         first_name=data.get("first_name"),
@@ -29,7 +30,7 @@ def _dict_to_model(data: dict):
         weight=data.get("weight", 0),
         bats=data.get("bats", "R"),
         primary_position=data.get("primary_position", ""),
-        other_positions=data.get("other_positions", "").split("|") if data.get("other_positions") else [],
+        other_positions=other_pos if isinstance(other_pos, list) else (other_pos.split("|") if other_pos else []),
         gf=data.get("gf", 0),
         injured=bool(data.get("injured", 0)),
         injury_description=data.get("injury_description"),

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
     QComboBox,
 )
+from PyQt6.QtCore import Qt
 from utils.trade_utils import load_trades, save_trade
 from utils.news_logger import log_news_event
 from utils.roster_loader import load_roster
@@ -29,7 +30,13 @@ class AdminDashboard(QWidget):
         self.setGeometry(200, 200, 500, 300)
 
         layout = QVBoxLayout()
-        layout.addWidget(QLabel("Welcome to the Admin Dashboard"))
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(15)
+
+        header = QLabel("Welcome to the Admin Dashboard")
+        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        header.setStyleSheet("font-size: 18px; font-weight: bold;")
+        layout.addWidget(header)
 
         self.review_button = QPushButton("Review Trades")
         self.review_button.clicked.connect(self.open_trade_review)
@@ -42,6 +49,13 @@ class AdminDashboard(QWidget):
         self.add_user_button = QPushButton("Add User")
         self.add_user_button.clicked.connect(self.open_add_user)
         layout.addWidget(self.add_user_button)
+
+        self.setStyleSheet(
+            """
+            QWidget {background-color: #f0f0f0; font-size: 14px;}
+            QPushButton {padding: 8px;}
+            """
+        )
 
         self.setLayout(layout)
 
@@ -180,6 +194,15 @@ class AdminDashboard(QWidget):
         dialog.exec()
 
     def open_create_league(self):
+        confirm = QMessageBox.question(
+            self,
+            "Overwrite Existing League?",
+            "Creating a new league will overwrite the current league and teams. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+
         div_text, ok = QInputDialog.getText(
             self, "Divisions", "Enter division names separated by commas:"
         )


### PR DESCRIPTION
## Summary
- Tidy the admin dashboard layout with padding, spacing, and a subtle stylesheet
- Add confirmation dialog when creating a league to prevent accidental overwrites
- Allow league creation to handle other_positions provided as a list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e2fbf588832ebcf01e05a96bdb1e