### PR TITLE
Fix admin dashboard text color

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -60,20 +60,7 @@ class AdminDashboard(QWidget):
 
         self.setStyleSheet(
             """
-            QWidget {background-color: #2c2c2c; color: #f0f0f0; font-size: 14px;}
-            QPushButton {
-                background-color: #444;
-                color: #f0f0f0;
-                padding: 8px;
-                border: 1px solid #555;
-            }
-            QPushButton:hover {background-color: #555;}
-            """
-        )
-
-        self.setStyleSheet(
-            """
-            QWidget {background-color: #f0f0f0; font-size: 14px;}
+            QWidget {background-color: #f0f0f0; color: #000000; font-size: 14px;}
             QPushButton {padding: 8px;}
             """
         )


### PR DESCRIPTION
## Summary
- Ensure admin dashboard text uses black color on light background
- Remove conflicting dark theme stylesheet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e64f213c832ea3238913546a2576