### PR TITLE
Support naming leagues

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -70,13 +70,14 @@ def _dict_to_model(data: dict):
         )
 
 
-def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], roster_size: int = 25):
+def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], league_name: str, roster_size: int = 25):
     os.makedirs(base_dir, exist_ok=True)
     rosters_dir = os.path.join(base_dir, "rosters")
     os.makedirs(rosters_dir, exist_ok=True)
 
     teams_path = os.path.join(base_dir, "teams.csv")
     players_path = os.path.join(base_dir, "players.csv")
+    league_path = os.path.join(base_dir, "league.txt")
 
     team_rows = []
     all_players = []
@@ -128,3 +129,5 @@ def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], ro
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(team_rows)
+    with open(league_path, "w", newline="") as f:
+        f.write(league_name)

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -6,15 +6,17 @@ from models.pitcher import Pitcher
 
 def test_create_league_generates_files(tmp_path):
     divisions = {"East": [("CityA", "Cats"), ("CityB", "Dogs")]}
-    create_league(str(tmp_path), divisions, roster_size=10)
+    create_league(str(tmp_path), divisions, "Test League", roster_size=10)
 
     teams_path = tmp_path / "teams.csv"
     players_path = tmp_path / "players.csv"
     rosters_dir = tmp_path / "rosters"
+    league_path = tmp_path / "league.txt"
 
     assert teams_path.exists()
     assert players_path.exists()
     assert rosters_dir.is_dir()
+    assert league_path.exists()
 
     with open(teams_path, newline="") as f:
         teams = list(csv.DictReader(f))
@@ -30,6 +32,8 @@ def test_create_league_generates_files(tmp_path):
         with open(r_file) as f:
             lines = [line for line in f.read().strip().splitlines() if line]
         assert len(lines) == 10
+    with open(league_path) as f:
+        assert f.read() == "Test League"
 
 
 def test_dict_to_model_defaults_pitcher_arm_to_fastball():

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -211,6 +211,13 @@ class AdminDashboard(QWidget):
         if confirm != QMessageBox.StandardButton.Yes:
             return
 
+        league_name, ok = QInputDialog.getText(
+            self, "League Name", "Enter league name:"
+        )
+        if not ok or not league_name:
+            return
+        league_name = league_name.strip()
+
         div_text, ok = QInputDialog.getText(
             self, "Divisions", "Enter division names separated by commas:"
         )
@@ -240,5 +247,5 @@ class AdminDashboard(QWidget):
             structure[div] = teams
 
         data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
-        create_league(data_dir, structure)
+        create_league(data_dir, structure, league_name)
         QMessageBox.information(self, "League Created", "New league generated.")


### PR DESCRIPTION
## Summary
- Prompt for a league name when creating a league through the admin UI
- Allow create_league to write the provided league name to league.txt
- Update tests for league creation to include the league name and verify the league file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897688db6e4832e9653499ebad41f34