### PR TITLE
Add dialog to enter teams when creating a league

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import (
     QComboBox,
 )
 from PyQt6.QtCore import Qt
+from ui.team_entry_dialog import TeamEntryDialog
 from utils.trade_utils import load_trades, save_trade
 from utils.news_logger import log_news_event
 from utils.roster_loader import load_roster
@@ -233,19 +234,11 @@ class AdminDashboard(QWidget):
         if not ok:
             return
 
-        structure = {}
-        for div in divisions:
-            teams = []
-            for i in range(teams_per_div):
-                city, ok = QInputDialog.getText(self, "Team City", f"{div} division - Team {i+1} city:")
-                if not ok:
-                    return
-                name, ok = QInputDialog.getText(self, "Team Name", f"{div} division - Team {i+1} name:")
-                if not ok:
-                    return
-                teams.append((city, name))
-            structure[div] = teams
+        dialog = TeamEntryDialog(divisions, teams_per_div, self)
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
 
+        structure = dialog.get_structure()
         data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
         create_league(data_dir, structure, league_name)
         QMessageBox.information(self, "League Created", "New league generated.")

--- a/ui/team_entry_dialog.py
+++ b/ui/team_entry_dialog.py
@@ -1,0 +1,63 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QMessageBox,
+)
+
+
+class TeamEntryDialog(QDialog):
+    """Dialog for entering team cities and nicknames."""
+
+    def __init__(self, divisions, teams_per_div, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Enter Teams")
+        self._inputs = {}
+
+        layout = QVBoxLayout()
+
+        for div in divisions:
+            layout.addWidget(QLabel(f"{div} Division"))
+            self._inputs[div] = []
+            for i in range(teams_per_div):
+                row = QHBoxLayout()
+                city_edit = QLineEdit()
+                city_edit.setPlaceholderText("City")
+                name_edit = QLineEdit()
+                name_edit.setPlaceholderText("Nickname")
+                row.addWidget(city_edit)
+                row.addWidget(name_edit)
+                layout.addLayout(row)
+                self._inputs[div].append((city_edit, name_edit))
+
+        btn_row = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        cancel_btn = QPushButton("Cancel")
+        btn_row.addWidget(save_btn)
+        btn_row.addWidget(cancel_btn)
+        layout.addLayout(btn_row)
+
+        save_btn.clicked.connect(self._handle_save)
+        cancel_btn.clicked.connect(self.reject)
+
+        self.setLayout(layout)
+
+    def _handle_save(self):
+        for fields in self._inputs.values():
+            for city, name in fields:
+                if not city.text().strip() or not name.text().strip():
+                    QMessageBox.warning(self, "Error", "All fields must be filled.")
+                    return
+        self.accept()
+
+    def get_structure(self):
+        structure = {}
+        for div, fields in self._inputs.items():
+            teams = []
+            for city, name in fields:
+                teams.append((city.text().strip(), name.text().strip()))
+            structure[div] = teams
+        return structure


### PR DESCRIPTION
## Summary
- Create `TeamEntryDialog` to gather city and nickname for all teams by division
- Update `open_create_league` to use the dialog and feed results to `create_league`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68976b5fccb4832e8ff964d05e00e97a