### PR TITLE
Add team name generator and randomize UI button

### DIFF
--- a/logic/team_name_generator.py
+++ b/logic/team_name_generator.py
@@ -1,0 +1,46 @@
+"""Utilities for generating random baseball team names.
+
+This module exposes lists of plausible cities and mascots along with a
+helper :func:`random_team` which returns a randomly selected
+``(city, mascot)`` pair. The lists are intentionally short but can be
+extended as needed and are primarily meant for demo data and quick UI
+entry.
+"""
+
+import random
+from typing import List, Tuple
+
+# Lists of sample cities and mascots.
+CITIES: List[str] = [
+    "New York",
+    "Los Angeles",
+    "Chicago",
+    "Houston",
+    "Phoenix",
+    "Philadelphia",
+    "San Antonio",
+    "San Diego",
+    "Dallas",
+    "San Jose",
+]
+
+MASCOTS: List[str] = [
+    "Bears",
+    "Tigers",
+    "Eagles",
+    "Sharks",
+    "Dragons",
+    "Wolves",
+    "Lions",
+    "Hawks",
+    "Rockets",
+    "Pirates",
+]
+
+def random_team() -> Tuple[str, str]:
+    """Return a random `(city, mascot)` pair.
+
+    The city is drawn from :data:`CITIES` and the mascot from :data:`MASCOTS`.
+    """
+
+    return random.choice(CITIES), random.choice(MASCOTS)

--- a/tests/test_team_name_generator.py
+++ b/tests/test_team_name_generator.py
@@ -1,0 +1,13 @@
+import random
+from logic.team_name_generator import random_team, CITIES, MASCOTS
+
+def test_random_team_returns_valid_members():
+    random.seed(0)
+    city, mascot = random_team()
+    assert city in CITIES
+    assert mascot in MASCOTS
+
+def test_random_team_produces_variety():
+    random.seed(1)
+    results = {random_team() for _ in range(20)}
+    assert len(results) > 1

--- a/ui/team_entry_dialog.py
+++ b/ui/team_entry_dialog.py
@@ -8,6 +8,8 @@ from PyQt6.QtWidgets import (
     QMessageBox,
 )
 
+from logic.team_name_generator import random_team
+
 
 class TeamEntryDialog(QDialog):
     """Dialog for entering team cities and nicknames."""
@@ -30,8 +32,13 @@ class TeamEntryDialog(QDialog):
                 name_edit.setPlaceholderText("Nickname")
                 row.addWidget(city_edit)
                 row.addWidget(name_edit)
+                random_btn = QPushButton("Randomize")
+                row.addWidget(random_btn)
                 layout.addLayout(row)
                 self._inputs[div].append((city_edit, name_edit))
+                random_btn.clicked.connect(
+                    lambda _, c=city_edit, n=name_edit: self._random_fill(c, n)
+                )
 
         btn_row = QHBoxLayout()
         save_btn = QPushButton("Save")
@@ -44,6 +51,12 @@ class TeamEntryDialog(QDialog):
         cancel_btn.clicked.connect(self.reject)
 
         self.setLayout(layout)
+
+    def _random_fill(self, city_edit: QLineEdit, name_edit: QLineEdit) -> None:
+        """Populate the provided fields with a random team name."""
+        city, nickname = random_team()
+        city_edit.setText(city)
+        name_edit.setText(nickname)
 
     def _handle_save(self):
         for fields in self._inputs.values():


### PR DESCRIPTION
## Summary
- introduce `team_name_generator` module with sample city and mascot lists and `random_team()` helper
- add “Randomize” button to `TeamEntryDialog` to fill team fields automatically
- cover team name generator with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976c2da01c832eaa4bb618bfa967dd