### PR TITLE
Ensure unique team names with resettable pools

### DIFF
--- a/logic/team_name_generator.py
+++ b/logic/team_name_generator.py
@@ -8,7 +8,7 @@ entry.
 """
 
 import random
-from typing import List, Tuple
+from typing import List, Set, Tuple
 
 # Lists of sample cities and mascots.
 CITIES: List[str] = [
@@ -22,6 +22,28 @@ CITIES: List[str] = [
     "San Diego",
     "Dallas",
     "San Jose",
+    "Austin",
+    "Jacksonville",
+    "Fort Worth",
+    "Columbus",
+    "Charlotte",
+    "San Francisco",
+    "Indianapolis",
+    "Seattle",
+    "Denver",
+    "Washington",
+    "Boston",
+    "El Paso",
+    "Nashville",
+    "Detroit",
+    "Oklahoma City",
+    "Portland",
+    "Las Vegas",
+    "Memphis",
+    "Louisville",
+    "Baltimore",
+    "Milwaukee",
+    "Albuquerque",
 ]
 
 MASCOTS: List[str] = [
@@ -35,12 +57,61 @@ MASCOTS: List[str] = [
     "Hawks",
     "Rockets",
     "Pirates",
+    "Knights",
+    "Warriors",
+    "Panthers",
+    "Bulls",
+    "Kings",
+    "Giants",
+    "Falcons",
+    "Rangers",
+    "Thunder",
+    "Saints",
+    "Wildcats",
+    "Spartans",
+    "Hornets",
+    "Raiders",
+    "Royals",
+    "Dolphins",
+    "Chargers",
+    "Coyotes",
+    "Jets",
+    "Mariners",
+    "Chiefs",
+    "Cardinals",
 ]
 
-def random_team() -> Tuple[str, str]:
-    """Return a random `(city, mascot)` pair.
+# Track used names to ensure uniqueness during generation.
+_used_cities: Set[str] = set()
+_used_mascots: Set[str] = set()
 
-    The city is drawn from :data:`CITIES` and the mascot from :data:`MASCOTS`.
+
+def random_team() -> Tuple[str, str]:
+    """Return a random `(city, mascot)` pair without repeats.
+
+    Cities and mascots are removed from the available pool after use. A
+    :class:`RuntimeError` is raised if no unused names remain.
     """
 
-    return random.choice(CITIES), random.choice(MASCOTS)
+    available_cities = [c for c in CITIES if c not in _used_cities]
+    if not available_cities:
+        raise RuntimeError("No unused city names remain.")
+
+    available_mascots = [m for m in MASCOTS if m not in _used_mascots]
+    if not available_mascots:
+        raise RuntimeError("No unused mascot names remain.")
+
+    city = random.choice(available_cities)
+    mascot = random.choice(available_mascots)
+
+    _used_cities.add(city)
+    _used_mascots.add(mascot)
+
+    return city, mascot
+
+
+def reset_name_pool() -> None:
+    """Clear tracking of used cities and mascots."""
+
+    _used_cities.clear()
+    _used_mascots.clear()

--- a/tests/test_team_name_generator.py
+++ b/tests/test_team_name_generator.py
@@ -1,5 +1,17 @@
 import random
-from logic.team_name_generator import random_team, CITIES, MASCOTS
+import pytest
+from logic.team_name_generator import (
+    CITIES,
+    MASCOTS,
+    random_team,
+    reset_name_pool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_name_pool():
+    """Ensure each test starts with a fresh name pool."""
+    reset_name_pool()
 
 def test_random_team_returns_valid_members():
     random.seed(0)
@@ -11,3 +23,11 @@ def test_random_team_produces_variety():
     random.seed(1)
     results = {random_team() for _ in range(20)}
     assert len(results) > 1
+
+
+def test_random_team_unique_until_exhaustion():
+    random.seed(2)
+    results = {random_team() for _ in range(32)}
+    assert len(results) == 32
+    with pytest.raises(RuntimeError):
+        random_team()

--- a/ui/team_entry_dialog.py
+++ b/ui/team_entry_dialog.py
@@ -54,7 +54,11 @@ class TeamEntryDialog(QDialog):
 
     def _random_fill(self, city_edit: QLineEdit, name_edit: QLineEdit) -> None:
         """Populate the provided fields with a random team name."""
-        city, nickname = random_team()
+        try:
+            city, nickname = random_team()
+        except RuntimeError as exc:
+            QMessageBox.warning(self, "Names Exhausted", str(exc))
+            return
         city_edit.setText(city)
         name_edit.setText(nickname)
 


### PR DESCRIPTION
## Summary
- expand city and mascot pools to 32 entries each
- track used names, provide `reset_name_pool`, and guarantee `random_team` uniqueness
- gracefully handle exhausted name pools in team entry dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68977012a39c832eb0d07a5dbd040b04