### PR TITLE
Add PB.INI configuration parser and tests

### DIFF
--- a/logic/pbini_loader.py
+++ b/logic/pbini_loader.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_pbini(path: str | Path) -> Dict[str, Dict[str, Any]]:
+    """Load a PB.INI style configuration file.
+
+    The file format uses ``key=value`` pairs and allows comments beginning
+    with ``;``. Section headers are surrounded by square brackets like
+    ``[Section]``. Values are converted to ``int`` when possible and otherwise
+    left as strings.
+    """
+    path = Path(path)
+    config: Dict[str, Dict[str, Any]] = {}
+    current_section: str | None = None
+
+    with path.open() as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith(";"):
+                continue
+
+            if line.startswith("[") and line.endswith("]"):
+                current_section = line[1:-1].strip()
+                config.setdefault(current_section, {})
+                continue
+
+            # Remove inline comments
+            if ";" in line:
+                line = line.split(";", 1)[0].strip()
+            if not line or "=" not in line:
+                continue
+
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+
+            # Convert numeric values when possible
+            try:
+                value_converted: Any = int(value)
+            except ValueError:
+                try:
+                    value_converted = float(value)
+                except ValueError:
+                    value_converted = value
+
+            section_dict = config.setdefault(current_section or "", {})
+            section_dict[key] = value_converted
+
+    return config
+
+
+__all__ = ["load_pbini"]

--- a/tests/test_pbini_loader.py
+++ b/tests/test_pbini_loader.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from logic.pbini_loader import load_pbini
+
+
+def test_load_pbini_parses_playbalance_section():
+    config = load_pbini(Path('logic/PBINI.txt'))
+    assert 'PlayBalance' in config
+    play = config['PlayBalance']
+    assert play['chargeChanceBaseFirst'] == 0
+    assert play['chargeChanceBaseThird'] == -20
+    assert play['holdChanceBase'] == 0
+
+
+def test_inline_comments_are_ignored(tmp_path):
+    ini_file = tmp_path / 'sample.ini'
+    ini_file.write_text('[Test]\na=1 ; comment\nb=2;another\n; c=3\n')
+    cfg = load_pbini(ini_file)
+    assert cfg['Test']['a'] == 1
+    assert cfg['Test']['b'] == 2
+    assert 'c' not in cfg['Test']


### PR DESCRIPTION
## Summary
- add `pbini_loader` to parse PB.INI files into sectioned dictionaries while ignoring semicolon comments
- cover parser with unit tests for sample entries and comment handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689785786920832eb3dfcd150e48e68c