### PR TITLE
Add pinch hitter not used test

### DIFF
--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -88,6 +88,20 @@ def test_pinch_hitter_used():
     assert stats.at_bats == 1
 
 
+def test_pinch_hitter_not_used():
+    cfg = load_config()
+    bench = make_player("bench", ph=10)
+    starter = make_player("start", ph=80)
+    home = TeamState(lineup=[make_player("h1")], bench=[], pitchers=[make_pitcher("hp")])
+    away = TeamState(lineup=[starter], bench=[bench], pitchers=[make_pitcher("ap")])
+    rng = MockRandom([0.9])  # swing(out)
+    sim = GameSimulation(home, away, cfg, rng)
+    sim.play_at_bat(away, home)
+    assert away.lineup[0].player_id == "start"
+    stats = away.lineup_stats["start"]
+    assert stats.at_bats == 1
+
+
 def test_steal_attempt_success():
     cfg = load_config()
     runner = make_player("run", ph=80, sp=90)


### PR DESCRIPTION
## Summary
- add regression test ensuring bench player with lower PH doesn't pinch hit and starter records the at-bat

## Testing
- `pytest tests/test_simulation.py::test_pinch_hitter_not_used -q`
- `pytest tests/test_simulation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689803ed49c4832eb24c7e10f1c930ff