### PR TITLE
Add roster menu actions to OwnerDashboard

### DIFF
--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -11,6 +11,9 @@ from PyQt6.QtGui import QFont
 
 from ui.lineup_editor import LineupEditor
 from ui.pitching_editor import PitchingEditor
+from ui.position_players_dialog import PositionPlayersDialog
+from ui.pitchers_window import PitchersWindow
+from ui.transactions_page import TransactionsPage
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
@@ -49,8 +52,14 @@ class OwnerDashboard(QWidget):
         # Menu bar
         menubar = QMenuBar()
         team_menu = menubar.addMenu("Team")
-        team_menu.addAction("Overview")
-        team_menu.addAction("Finances")
+        pos_action = team_menu.addAction("Position Players")
+        pit_action = team_menu.addAction("Pitchers")
+        lineups_action = team_menu.addAction("Lineups")
+        trans_action = team_menu.addAction("Transactions")
+        pos_action.triggered.connect(self.open_position_players_dialog)
+        pit_action.triggered.connect(self.open_pitchers_window)
+        lineups_action.triggered.connect(self.open_lineup_editor)
+        trans_action.triggered.connect(self.open_transactions_page)
         league_menu = menubar.addMenu("League")
         league_menu.addAction("Standings")
         league_menu.addAction("Schedule")
@@ -174,6 +183,15 @@ class OwnerDashboard(QWidget):
 
     def open_pitching_editor(self):
         PitchingEditor(self.team_id).exec()
+
+    def open_position_players_dialog(self):
+        PositionPlayersDialog(self.team_id).exec()
+
+    def open_pitchers_window(self):
+        PitchersWindow(self.team_id).exec()
+
+    def open_transactions_page(self):
+        TransactionsPage(self.team_id).exec()
 
     def move_selected_player(self):
         current_tab = self.tabs.currentIndex()

--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -1,0 +1,12 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel
+
+
+class PitchersWindow(QDialog):
+    """Placeholder window for managing pitchers."""
+
+    def __init__(self, team_id: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Pitchers")
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel(f"Pitchers for {team_id}"))
+        self.setLayout(layout)

--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -1,0 +1,12 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel
+
+
+class PositionPlayersDialog(QDialog):
+    """Simple placeholder dialog for listing position players."""
+
+    def __init__(self, team_id: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Position Players")
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel(f"Position players for {team_id}"))
+        self.setLayout(layout)

--- a/ui/transactions_page.py
+++ b/ui/transactions_page.py
@@ -1,0 +1,12 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel
+
+
+class TransactionsPage(QDialog):
+    """Placeholder dialog for team transactions."""
+
+    def __init__(self, team_id: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Transactions")
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel(f"Transactions for {team_id}"))
+        self.setLayout(layout)


### PR DESCRIPTION
## Summary
- Extend OwnerDashboard menu with Position Players, Pitchers, Lineups, and Transactions actions.
- Implement handlers opening corresponding dialogs/windows.
- Provide placeholder UI dialogs for position players, pitchers, and transactions.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981186ac18832eb75c7fb8e44a46ea