### PR TITLE
Add placeholder transactions window to owner dashboard

### DIFF
--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -13,7 +13,7 @@ from ui.lineup_editor import LineupEditor
 from ui.pitching_editor import PitchingEditor
 from ui.position_players_dialog import PositionPlayersDialog
 from ui.pitchers_window import PitchersWindow
-from ui.transactions_page import TransactionsPage
+from ui.transactions_window import TransactionsWindow
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
@@ -191,7 +191,7 @@ class OwnerDashboard(QWidget):
         PitchersWindow(self.players, self.roster).exec()
 
     def open_transactions_page(self):
-        TransactionsPage(self.team_id).exec()
+        TransactionsWindow().exec()
 
     def move_selected_player(self):
         current_tab = self.tabs.currentIndex()

--- a/ui/transactions_window.py
+++ b/ui/transactions_window.py
@@ -1,0 +1,16 @@
+"""Placeholder dialog for future transaction features."""
+
+from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout
+
+
+class TransactionsWindow(QDialog):
+    """Simple dialog announcing upcoming transaction tools."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Transactions")
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("Coming soon"))
+        self.setLayout(layout)
+


### PR DESCRIPTION
## Summary
- add a simple `TransactionsWindow` dialog placeholder
- hook up owner dashboard to open the new transactions dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898174c72e8832eabe6e0169ef4a54c