### PR TITLE
Purge users and rosters when creating league

### DIFF
--- a/logic/league_creator.py
+++ b/logic/league_creator.py
@@ -1,10 +1,12 @@
 import os
 import csv
+import shutil
 from typing import Dict, List, Tuple
 from models.player import Player
 from models.pitcher import Pitcher
 from utils.player_writer import save_players_to_csv
 from logic.player_generator import generate_player
+from utils.user_manager import clear_users
 
 
 def _abbr(city: str, name: str, existing: set) -> str:
@@ -74,7 +76,11 @@ def _dict_to_model(data: dict):
 def create_league(base_dir: str, divisions: Dict[str, List[Tuple[str, str]]], league_name: str, roster_size: int = 25):
     os.makedirs(base_dir, exist_ok=True)
     rosters_dir = os.path.join(base_dir, "rosters")
+    if os.path.exists(rosters_dir):
+        shutil.rmtree(rosters_dir)
     os.makedirs(rosters_dir, exist_ok=True)
+
+    clear_users()
 
     teams_path = os.path.join(base_dir, "teams.csv")
     players_path = os.path.join(base_dir, "players.csv")

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -86,3 +86,27 @@ def test_dict_to_model_defaults_pitcher_arm_to_fastball():
     assert isinstance(pitcher, Pitcher)
     assert pitcher.arm == 70
     assert pitcher.potential["arm"] == 70
+
+
+def test_create_league_clears_users_and_rosters(tmp_path, monkeypatch):
+    # Set up temporary users file and stray roster file
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    users_file = data_dir / "users.txt"
+    users_file.write_text("olduser,pw,admin,\n")
+
+    base_dir = tmp_path / "league"
+    rosters_dir = base_dir / "rosters"
+    rosters_dir.mkdir(parents=True)
+    stray = rosters_dir / "OLD.csv"
+    stray.write_text("junk")
+
+    divisions = {"East": [("CityA", "Cats")]}  # single team for simplicity
+
+    # Ensure clear_users operates on our temporary data directory
+    monkeypatch.chdir(tmp_path)
+
+    create_league(str(base_dir), divisions, "Test League", roster_size=2)
+
+    assert not users_file.exists()
+    assert not stray.exists()

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -240,5 +240,9 @@ class AdminDashboard(QWidget):
 
         structure = dialog.get_structure()
         data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
-        create_league(data_dir, structure, league_name)
+        try:
+            create_league(data_dir, structure, league_name)
+        except OSError as e:
+            QMessageBox.critical(self, "Error", f"Failed to purge existing league: {e}")
+            return
         QMessageBox.information(self, "League Created", "New league generated.")

--- a/utils/user_manager.py
+++ b/utils/user_manager.py
@@ -58,3 +58,9 @@ def add_user(
 
     with open(file_path, "a") as f:
         f.write(f"{username},{password},{role},{team_id}\n")
+
+
+def clear_users(file_path: str = "data/users.txt") -> None:
+    """Remove all user accounts by deleting the users file if it exists."""
+    if os.path.exists(file_path):
+        os.remove(file_path)


### PR DESCRIPTION
## Summary
- Add `clear_users` helper to wipe user accounts
- Clear existing rosters directory and users when creating a league
- Handle purge errors in admin dashboard and test behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68981f1be678832e82a87410969ff9a8