### PR TITLE
Add multi-level roster generation and age controls

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -1,7 +1,7 @@
 # ARR-inspired Player Generator Script
 import random
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Tuple, Set, Optional
 import csv
 import os
 
@@ -233,8 +233,15 @@ def generate_pitches(throws: str, delivery: str, age: int):
     potentials = {f"pot_{p}": bounded_potential(ratings[p], age) if p in selected else 0 for p in PITCH_LIST}
     return ratings, potentials
 
-def generate_player(is_pitcher: bool, for_draft: bool = False) -> Dict:
-    birthdate, age = generate_birthdate((17, 21) if for_draft else (18, 38))
+def generate_player(
+    is_pitcher: bool,
+    for_draft: bool = False,
+    age_range: Optional[Tuple[int, int]] = None,
+    primary_position: Optional[str] = None,
+) -> Dict:
+    birthdate, age = generate_birthdate(
+        age_range if age_range else ((17, 21) if for_draft else (18, 38))
+    )
     first_name, last_name = generate_name()
     player_id = f"P{random.randint(1000, 9999)}"
     height = random.randint(68, 78)
@@ -289,7 +296,7 @@ def generate_player(is_pitcher: bool, for_draft: bool = False) -> Dict:
         return player
 
     else:
-        primary_pos = assign_primary_position()
+        primary_pos = primary_position or assign_primary_position()
         bats, throws = assign_bats_throws(primary_pos)
         other_pos = assign_secondary_positions(primary_pos)
         ch = bounded_rating()

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -8,7 +8,7 @@ import random
 
 def test_create_league_generates_files(tmp_path):
     divisions = {"East": [("CityA", "Cats"), ("CityB", "Dogs")]}
-    create_league(str(tmp_path), divisions, "Test League", roster_size=10)
+    create_league(str(tmp_path), divisions, "Test League")
 
     teams_path = tmp_path / "teams.csv"
     players_path = tmp_path / "players.csv"
@@ -26,14 +26,16 @@ def test_create_league_generates_files(tmp_path):
 
     with open(players_path, newline="") as f:
         players = list(csv.DictReader(f))
-    assert len(players) == 20
+    assert len(players) == 100
 
     for t in teams:
         r_file = rosters_dir / f"{t['team_id']}.csv"
         assert r_file.exists()
         with open(r_file) as f:
             lines = [line for line in f.read().strip().splitlines() if line]
-        assert len(lines) == 10
+        assert len(lines) == 50
+        levels = {line.split(',')[1] for line in lines}
+        assert levels == {"ACT", "AAA", "LOW"}
     with open(league_path) as f:
         assert f.read() == "Test League"
 
@@ -42,7 +44,7 @@ def test_create_league_uses_unique_names(tmp_path):
     reset_name_cache()
     random.seed(0)
     divisions = {"East": [("CityA", "Cats")]}  # single team for simplicity
-    create_league(str(tmp_path), divisions, "Test League", roster_size=10)
+    create_league(str(tmp_path), divisions, "Test League")
 
     players_path = tmp_path / "players.csv"
     with open(players_path, newline="") as f:
@@ -106,7 +108,7 @@ def test_create_league_clears_users_and_rosters(tmp_path, monkeypatch):
     # Ensure clear_users operates on our temporary data directory
     monkeypatch.chdir(tmp_path)
 
-    create_league(str(base_dir), divisions, "Test League", roster_size=2)
+    create_league(str(base_dir), divisions, "Test League")
 
     assert not users_file.exists()
     assert not stray.exists()


### PR DESCRIPTION
## Summary
- Generate ACT, AAA, and LOW rosters for each club with age-based constraints
- Extend player generator to allow age ranges and forced positions
- Update league creation tests for multi-level roster outputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689827b76768832eb64f24b70e9c5fbb