### PR TITLE
Align pitcher role with endurance rating

### DIFF
--- a/logic/player_generator.py
+++ b/logic/player_generator.py
@@ -274,13 +274,13 @@ def generate_player(
 
     if is_pitcher:
         bats, throws = assign_bats_throws("P")
-        role = random.choice(["SP", "RP"])
+        endurance = bounded_rating()
+        role = "SP" if endurance > 55 else "RP"
         delivery = random.choices(["overhand", "sidearm"], weights=[95, 5])[0]
         arm = bounded_rating()
         fa = bounded_rating()
         control = bounded_rating()
         movement = bounded_rating()
-        endurance = bounded_rating()
         hold_runner = bounded_rating()
         pitch_ratings, pitch_pots = generate_pitches(throws, delivery, age)
 

--- a/tests/test_player_generator.py
+++ b/tests/test_player_generator.py
@@ -2,6 +2,7 @@ from datetime import date
 import random
 
 from logic.player_generator import generate_player, assign_primary_position
+import logic.player_generator as pg
 
 
 def test_generate_player_respects_age_range():
@@ -20,3 +21,29 @@ def test_primary_position_override():
     random.seed(0)
     player = generate_player(is_pitcher=False, primary_position="SS")
     assert player["primary_position"] == "SS"
+
+
+def test_pitcher_role_sp_when_endurance_high(monkeypatch):
+    def fake_bounded_rating_high(min_val=10, max_val=99):
+        fake_bounded_rating_high.calls += 1
+        return 60 if fake_bounded_rating_high.calls == 1 else 50
+
+    fake_bounded_rating_high.calls = 0
+    monkeypatch.setattr(pg, "bounded_rating", fake_bounded_rating_high)
+
+    player = generate_player(is_pitcher=True)
+    assert player["endurance"] == 60
+    assert player["role"] == "SP"
+
+
+def test_pitcher_role_rp_when_endurance_low(monkeypatch):
+    def fake_bounded_rating_low(min_val=10, max_val=99):
+        fake_bounded_rating_low.calls += 1
+        return 55 if fake_bounded_rating_low.calls == 1 else 50
+
+    fake_bounded_rating_low.calls = 0
+    monkeypatch.setattr(pg, "bounded_rating", fake_bounded_rating_low)
+
+    player = generate_player(is_pitcher=True)
+    assert player["endurance"] == 55
+    assert player["role"] == "RP"


### PR DESCRIPTION
## Summary
- Determine pitcher role from endurance: starters require endurance > 55
- Move endurance generation before assigning role
- Test pitcher generation for both starter and reliever paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898303e6234832e8c3c814408780c5b