### PR TITLE
Double PositionPlayersDialog default width

### DIFF
--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -37,6 +37,9 @@ class PositionPlayersDialog(QDialog):
         layout.addStretch()
         self.setLayout(layout)
 
+        size = self.sizeHint()
+        self.resize(size.width() * 2, size.height())
+
     # ------------------------------------------------------------------
     # Section builders
     def _build_level_section(self, label: str, player_ids: Iterable[str]) -> QGroupBox:


### PR DESCRIPTION
## Summary
- Expand PositionPlayersDialog startup width to show all position tabs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d1c4af18832ebadf221cbeb8bfa6