### PR TITLE
Double PitchersWindow default width

### DIFF
--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -35,6 +35,9 @@ class PitchersWindow(QDialog):
         layout.addStretch()
         self.setLayout(layout)
 
+        size = self.sizeHint()
+        self.resize(size.width() * 2, size.height())
+
     # ------------------------------------------------------------------
     # Builders
     def _build_level_group(self, title: str, player_ids: Iterable[str]) -> QGroupBox:


### PR DESCRIPTION
## Summary
- Double the default width of the pitchers window for better visibility of grouped rosters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d3a811f0832e8229e82dba01bab6