### PR TITLE
Add role column to tests and persist pitcher roles

### DIFF
--- a/models/pitcher.py
+++ b/models/pitcher.py
@@ -8,6 +8,7 @@ class Pitcher(BasePlayer):
     control: int = 0
     movement: int = 0
     hold_runner: int = 0
+    role: str = ""
 
     fb: int = 0
     cu: int = 0

--- a/tests/test_player_loader.py
+++ b/tests/test_player_loader.py
@@ -17,6 +17,7 @@ def test_load_player_with_optional_columns_missing(tmp_path):
         "primary_position",
         "gf",
         "is_pitcher",
+        "role",
         "ch",
         "ph",
         "sp",
@@ -41,6 +42,7 @@ def test_load_player_with_optional_columns_missing(tmp_path):
                 "primary_position": "1B",
                 "gf": "50",
                 "is_pitcher": "false",
+                "role": "",
                 "ch": "60",
                 "ph": "55",
                 "sp": "70",
@@ -74,6 +76,7 @@ def test_missing_required_numeric_field_raises(tmp_path):
         "primary_position",
         "gf",
         "is_pitcher",
+        "role",
         "ch",
         "ph",
         "sp",
@@ -98,6 +101,7 @@ def test_missing_required_numeric_field_raises(tmp_path):
                 "primary_position": "1B",
                 "gf": "50",
                 "is_pitcher": "false",
+                "role": "",
                 "ch": "60",
                 "ph": "55",
                 "sp": "70",
@@ -125,6 +129,7 @@ def test_numeric_is_pitcher_creates_pitcher(tmp_path):
         "primary_position",
         "gf",
         "is_pitcher",
+        "role",
         "endurance",
         "control",
         "movement",
@@ -152,6 +157,7 @@ def test_numeric_is_pitcher_creates_pitcher(tmp_path):
                 "primary_position": "P",
                 "gf": "10",
                 "is_pitcher": "1",
+                "role": "SP",
                 "endurance": "40",
                 "control": "50",
                 "movement": "35",
@@ -170,6 +176,7 @@ def test_numeric_is_pitcher_creates_pitcher(tmp_path):
     assert len(players) == 1
     player = players[0]
     assert isinstance(player, Pitcher)
+    assert player.role == "SP"
     assert player.endurance > 0 and player.control > 0
     assert player.arm == 60
 
@@ -187,6 +194,7 @@ def test_pitcher_arm_defaults_to_fastball(tmp_path):
         "primary_position",
         "gf",
         "is_pitcher",
+        "role",
         "endurance",
         "control",
         "movement",
@@ -215,6 +223,7 @@ def test_pitcher_arm_defaults_to_fastball(tmp_path):
                 "primary_position": "SP",
                 "gf": "5",
                 "is_pitcher": "1",
+                "role": "SP",
                 "endurance": "50",
                 "control": "60",
                 "movement": "55",
@@ -233,4 +242,5 @@ def test_pitcher_arm_defaults_to_fastball(tmp_path):
     assert len(players) == 1
     player = players[0]
     assert isinstance(player, Pitcher)
+    assert player.role == "SP"
     assert player.arm == 70

--- a/tests/test_player_writer.py
+++ b/tests/test_player_writer.py
@@ -1,6 +1,7 @@
 import csv
 from models.player import Player
 from models.pitcher import Pitcher
+from utils.player_loader import load_players_from_csv
 from utils.player_writer import save_players_to_csv
 
 
@@ -18,6 +19,7 @@ def test_save_players_to_csv_marks_pitchers(tmp_path):
         other_positions=[],
         gf=10,
         arm=50,
+        role="SP",
     )
     hitter = Player(
         player_id="h1",
@@ -36,6 +38,11 @@ def test_save_players_to_csv_marks_pitchers(tmp_path):
     with open(file_path, newline="") as f:
         reader = csv.DictReader(f)
         rows = list(reader)
-    rows_by_id = {row["player_id"]: row["is_pitcher"] for row in rows}
-    assert rows_by_id["p1"] == "1"
-    assert rows_by_id["h1"] == "0"
+    rows_by_id = {
+        row["player_id"]: (row["is_pitcher"], row.get("role", "")) for row in rows
+    }
+    assert rows_by_id["p1"] == ("1", "SP")
+    assert rows_by_id["h1"] == ("0", "")
+    loaded_players = load_players_from_csv(file_path)
+    roles = {p.player_id: getattr(p, "role", "") for p in loaded_players if isinstance(p, Pitcher)}
+    assert roles["p1"] == "SP"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -42,7 +42,9 @@ def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
     )
 
 
-def make_pitcher(pid: str, endurance: int = 100, hold_runner: int = 50) -> Pitcher:
+def make_pitcher(
+    pid: str, endurance: int = 100, hold_runner: int = 50, role: str = "SP"
+) -> Pitcher:
     return Pitcher(
         player_id=pid,
         first_name="PF" + pid,
@@ -67,6 +69,7 @@ def make_pitcher(pid: str, endurance: int = 100, hold_runner: int = 50) -> Pitch
         kn=0,
         arm=50,
         fa=50,
+        role=role,
     )
 
 

--- a/utils/player_loader.py
+++ b/utils/player_loader.py
@@ -50,6 +50,7 @@ def load_players_from_csv(file_path):
                 control = _required_int(row, "control")
                 movement = _required_int(row, "movement")
                 hold_runner = _required_int(row, "hold_runner")
+                role = row.get("role", "")
                 fb = _required_int(row, "fb")
                 cu = _required_int(row, "cu")
                 cb = _required_int(row, "cb")
@@ -74,6 +75,7 @@ def load_players_from_csv(file_path):
                     si=si,
                     scb=scb,
                     kn=kn,
+                    role=role,
                     arm=arm,
                     fa=fa,
                     potential={

--- a/utils/player_writer.py
+++ b/utils/player_writer.py
@@ -5,7 +5,7 @@ from models.pitcher import Pitcher
 def save_players_to_csv(players, file_path):
     fieldnames = [
         "player_id", "first_name", "last_name", "birthdate", "height", "weight", "bats",
-        "primary_position", "other_positions", "is_pitcher",
+        "primary_position", "other_positions", "is_pitcher", "role",
         "ch", "ph", "sp", "gf", "pl", "vl", "sc", "fa", "arm",
         "endurance", "control", "movement", "hold_runner",
         "fb", "cu", "cb", "sl", "si", "scb", "kn",
@@ -32,6 +32,7 @@ def save_players_to_csv(players, file_path):
                 "primary_position": p.primary_position,
                 "other_positions": "|".join(p.other_positions),
                 "is_pitcher": "1" if is_pitcher else "0",
+                "role": p.role if is_pitcher else "",
                 "injured": str(p.injured),
                 "injury_description": p.injury_description or "",
                 "return_date": p.return_date or ""


### PR DESCRIPTION
## Summary
- Include a `role` attribute on `Pitcher` and handle it in player load/save utilities
- Add `role` column to test CSV fixtures and verify roles survive load/save cycles
- Update test helpers to provide valid pitcher roles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d77adf10832e9e92f0e3d8ce08c1