### PR TITLE
Add unified pitcher role helper and apply across UI

### DIFF
--- a/tests/test_pitcher_role.py
+++ b/tests/test_pitcher_role.py
@@ -1,0 +1,56 @@
+import pytest
+
+from models.pitcher import Pitcher
+from utils.pitcher_role import get_role, ENDURANCE_THRESHOLD
+
+
+def make_pitcher(**kwargs):
+    defaults = dict(
+        player_id="p1",
+        first_name="A",
+        last_name="B",
+        birthdate="2000-01-01",
+        height=70,
+        weight=180,
+        bats="R",
+        primary_position="P",
+        other_positions=[],
+        gf=0,
+        endurance=50,
+        control=0,
+        movement=0,
+        hold_runner=0,
+        role="",
+    )
+    defaults.update(kwargs)
+    return Pitcher(**defaults)
+
+
+def test_explicit_role_overrides_primary_and_endurance():
+    p = make_pitcher(role="SP", primary_position="RP", endurance=0)
+    assert get_role(p) == "SP"
+
+
+def test_primary_position_used_when_role_missing():
+    p = make_pitcher(primary_position="RP")
+    assert get_role(p) == "RP"
+
+
+def test_endurance_high_yields_sp():
+    p = make_pitcher(endurance=ENDURANCE_THRESHOLD + 1)
+    assert get_role(p) == "SP"
+
+
+def test_endurance_low_yields_rp():
+    p = make_pitcher(endurance=ENDURANCE_THRESHOLD)
+    assert get_role(p) == "RP"
+
+
+def test_returns_empty_for_non_pitcher():
+    hitter = {"primary_position": "CF"}
+    assert get_role(hitter) == ""
+
+
+def test_accepts_dict_objects():
+    pdata = {"role": "RP", "endurance": 10, "primary_position": "P"}
+    assert get_role(pdata) == "RP"

--- a/ui/lineup_editor.py
+++ b/ui/lineup_editor.py
@@ -3,6 +3,7 @@ from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt, QPropertyAnimation
 import os
 import csv
+from utils.pitcher_role import get_role
 
 class LineupEditor(QDialog):
     def __init__(self, team_id):
@@ -263,7 +264,7 @@ class LineupEditor(QDialog):
         act_ids = self.get_act_level_ids()
         bench_players = sorted(
             [pdata["name"] for pid, pdata in self.players_dict.items()
-             if pid in act_ids and pid not in used_ids and pdata.get("primary_position") not in ["SP", "RP", "P"]]
+             if pid in act_ids and pid not in used_ids and not get_role(pdata)]
         )
 
         columns = [[], [], []]

--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -15,12 +15,11 @@ from PyQt6.QtWidgets import (
 
 from models.base_player import BasePlayer
 from models.roster import Roster
+from utils.pitcher_role import get_role
 
 
 class PitchersWindow(QDialog):
     """Display all pitchers grouped by roster level with tabs for roles."""
-
-    pitcher_positions = {"SP", "RP", "P"}
 
     def __init__(self, players: Dict[str, BasePlayer], roster: Roster, parent=None):
         super().__init__(parent)
@@ -50,12 +49,10 @@ class PitchersWindow(QDialog):
         groups = {"SP": [], "RP": []}
         for pid in player_ids:
             p = self.players.get(pid)
-            if not p or p.primary_position not in self.pitcher_positions:
+            role = get_role(p) if p else ""
+            if not role:
                 continue
-            if p.primary_position == "SP":
-                groups["SP"].append(p)
-            else:
-                groups["RP"].append(p)
+            groups[role].append(p)
 
         tab_widget = QTabWidget()
         for role, players in groups.items():
@@ -76,7 +73,8 @@ class PitchersWindow(QDialog):
     def _make_pitcher_item(self, p: BasePlayer) -> QListWidgetItem:
         age = self._calculate_age(p.birthdate)
         core = f"AS:{getattr(p, 'arm', 0)} EN:{getattr(p, 'endurance', 0)} CO:{getattr(p, 'control', 0)}"
-        label = f"{p.first_name} {p.last_name} ({age}) - {p.primary_position} | {core}"
+        role = get_role(p)
+        label = f"{p.first_name} {p.last_name} ({age}) - {role or p.primary_position} | {core}"
         item = QListWidgetItem(label)
         item.setData(Qt.ItemDataRole.UserRole, p.player_id)
         return item

--- a/ui/pitching_editor.py
+++ b/ui/pitching_editor.py
@@ -1,6 +1,7 @@
 from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout, QGridLayout, QComboBox, QPushButton, QMessageBox
 import os
 import csv
+from utils.pitcher_role import get_role
 
 class PitchingEditor(QDialog):
     def __init__(self, team_id):
@@ -22,7 +23,7 @@ class PitchingEditor(QDialog):
             label = QLabel(role)
             dropdown = QComboBox()
             for pid, pdata in self.players_dict.items():
-                if pid in self.act_ids and pdata["primary_position"] in ["SP", "RP", "P"]:
+                if pid in self.act_ids and get_role(pdata):
                     dropdown.addItem(pdata["name"], userData=pid)
             self.pitcher_dropdowns[role] = dropdown
             grid.addWidget(label, i, 0)
@@ -99,7 +100,7 @@ class PitchingEditor(QDialog):
 
     def autofill_staff(self):
         available = [pid for pid, pdata in self.players_dict.items()
-                     if pid in self.act_ids and pdata["primary_position"] in ["SP", "RP", "P"]]
+                     if pid in self.act_ids and get_role(pdata)]
         used = set()
         for role in self.roles:
             dropdown = self.pitcher_dropdowns[role]

--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -15,12 +15,12 @@ from PyQt6.QtWidgets import (
 
 from models.base_player import BasePlayer
 from models.roster import Roster
+from utils.pitcher_role import get_role
 
 
 class PositionPlayersDialog(QDialog):
     """Display all position players grouped by roster level and position."""
 
-    pitcher_positions = {"SP", "RP", "P"}
     position_order = ["C", "1B", "2B", "SS", "3B", "LF", "CF", "RF"]
 
     def __init__(self, players: Dict[str, BasePlayer], roster: Roster, parent=None):
@@ -51,7 +51,7 @@ class PositionPlayersDialog(QDialog):
         groups = {}
         for pid in player_ids:
             p = self.players.get(pid)
-            if not p or p.primary_position in self.pitcher_positions:
+            if not p or get_role(p):
                 continue
             groups.setdefault(p.primary_position, []).append(p)
 
@@ -75,13 +75,12 @@ class PositionPlayersDialog(QDialog):
         """Format a player entry similar to OwnerDashboard._make_player_item."""
 
         age = self._calculate_age(p.birthdate)
-        role = getattr(p, "role", "")
-        is_pitcher_role = bool(role)
-        if is_pitcher_role:
+        role = get_role(p)
+        if role:
             core = f"AS:{getattr(p, 'arm', 0)} EN:{getattr(p, 'endurance', 0)} CO:{getattr(p, 'control', 0)}"
         else:
             core = f"CH:{getattr(p, 'ch', 0)} PH:{getattr(p, 'ph', 0)} SP:{getattr(p, 'sp', 0)}"
-        label = f"{p.first_name} {p.last_name} ({age}) - {p.primary_position} | {core}"
+        label = f"{p.first_name} {p.last_name} ({age}) - {role or p.primary_position} | {core}"
         item = QListWidgetItem(label)
         item.setData(Qt.ItemDataRole.UserRole, p.player_id)
         return item

--- a/utils/pitcher_role.py
+++ b/utils/pitcher_role.py
@@ -1,0 +1,48 @@
+"""Utilities for determining pitcher roles."""
+
+from __future__ import annotations
+from typing import Any
+
+ENDURANCE_THRESHOLD = 55
+
+def _get_attr(obj: Any, attr: str, default: Any = None) -> Any:
+    """Return attribute or dict key value from *obj* if present."""
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default)
+
+def get_role(pitcher: Any) -> str:
+    """Return the role for *pitcher* as ``"SP"`` or ``"RP"``.
+
+    The role is determined in the following order:
+    1. Use the stored ``role`` attribute or key if it is ``"SP"`` or ``"RP"``.
+    2. Fall back to ``primary_position`` if it is ``"SP"`` or ``"RP"``.
+    3. Derive from ``endurance`` using ``ENDURANCE_THRESHOLD``.
+       Pitchers with endurance greater than the threshold are considered
+       starters, otherwise relievers.
+
+    If *pitcher* does not appear to be a pitcher, an empty string is
+    returned.  The function accepts either objects with attributes or
+    dictionaries with matching keys.
+    """
+
+    role = str(_get_attr(pitcher, "role", "")).upper()
+    if role in {"SP", "RP"}:
+        return role
+
+    primary = str(_get_attr(pitcher, "primary_position", "")).upper()
+    if primary in {"SP", "RP"}:
+        return primary
+    if primary and primary not in {"SP", "RP", "P"}:
+        return ""
+
+    endurance = _get_attr(pitcher, "endurance")
+    try:
+        endurance = int(endurance)
+    except (TypeError, ValueError):
+        endurance = None
+
+    if endurance is None:
+        return ""
+
+    return "SP" if endurance > ENDURANCE_THRESHOLD else "RP"


### PR DESCRIPTION
## Summary
- add `utils.pitcher_role.get_role` to derive SP/RP roles with endurance fallback
- replace direct role checks in UI components with helper usage
- test role helper across explicit, inferred and non-pitcher scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898de18c670832ea4c6fe88cb483b93