### PR TITLE
Add splash screen that routes to login

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import sys
 from PyQt6.QtWidgets import QApplication
-from ui.login_window import LoginWindow
+from ui.splash_screen import SplashScreen
 
 def main():
     app = QApplication(sys.argv)
-    login = LoginWindow()
-    login.show()
+    splash = SplashScreen()
+    splash.show()
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -1,0 +1,41 @@
+import os
+from PyQt6.QtWidgets import QWidget, QLabel, QPushButton, QVBoxLayout
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtCore import Qt
+
+from ui.login_window import LoginWindow
+
+class SplashScreen(QWidget):
+    """Initial splash screen displaying the UBL logo and login button."""
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("UBL")
+
+        layout = QVBoxLayout()
+        layout.addStretch()
+
+        logo_label = QLabel()
+        logo_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "logo",
+            "UBL.png",
+        )
+        logo_label.setPixmap(QPixmap(logo_path))
+        logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(logo_label)
+
+        layout.addStretch()
+
+        self.login_button = QPushButton("Login")
+        self.login_button.clicked.connect(self.open_login)
+        layout.addWidget(self.login_button, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        self.setLayout(layout)
+        self.login_window = None
+
+    def open_login(self):
+        """Show the login window and close the splash screen."""
+        self.login_window = LoginWindow()
+        self.login_window.show()
+        self.close()


### PR DESCRIPTION
## Summary
- Add `SplashScreen` widget that displays the UBL logo and a centered **Login** button which launches the existing login window
- Start application with the new splash screen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a64fd9908832eb96130d2ac0670bb