### PR TITLE
Use background image and start button on splash screen

### DIFF
--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -1,6 +1,5 @@
 import os
-from PyQt6.QtWidgets import QWidget, QLabel, QPushButton, QVBoxLayout
-from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import QWidget, QPushButton, QVBoxLayout
 from PyQt6.QtCore import Qt
 
 from ui.login_window import LoginWindow
@@ -15,22 +14,22 @@ class SplashScreen(QWidget):
         layout = QVBoxLayout()
         layout.addStretch()
 
-        logo_label = QLabel()
         logo_path = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             "logo",
             "UBL.png",
         )
-        logo_label.setPixmap(QPixmap(logo_path))
-        logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(logo_label)
+        self.setStyleSheet(
+            f"background-image: url({logo_path}); background-repeat: no-repeat; background-position: center;"
+        )
 
-        layout.addStretch()
+        self.start_button = QPushButton("Start Game")
+        self.start_button.setFixedSize(200, 60)
+        self.start_button.setStyleSheet("font-size: 20px;")
+        self.start_button.clicked.connect(self.open_login)
+        layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignHCenter)
 
-        self.login_button = QPushButton("Login")
-        self.login_button.clicked.connect(self.open_login)
-        layout.addWidget(self.login_button, alignment=Qt.AlignmentFlag.AlignCenter)
-
+        layout.setContentsMargins(0, 0, 0, 150)
         self.setLayout(layout)
         self.login_window = None
 


### PR DESCRIPTION
## Summary
- display the UBL logo as the splash screen background
- rename login button to a styled "Start Game" button and center it

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6759ce4c832ea4870528f49a418e