### PR TITLE
Make splash screen logo fill window background

### DIFF
--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -11,14 +11,19 @@ class SplashScreen(QWidget):
         super().__init__()
         self.setWindowTitle("UBL")
 
+        self.setObjectName("splash_screen")
+
         layout = QVBoxLayout()
         layout.addStretch()
 
         logo_path = Path(__file__).resolve().parents[1] / "logo" / "UBL.png"
         logo_url = logo_path.as_posix()
         self.setStyleSheet(
-            f"background-image: url('{logo_url}');"
-            "background-repeat: no-repeat; background-position: center;"
+            f"""
+            #splash_screen {{
+                border-image: url('{logo_url}') 0 0 0 0 stretch stretch;
+            }}
+            """
         )
 
         self.start_button = QPushButton("Start Game")


### PR DESCRIPTION
## Summary
- Ensure splash screen's logo image covers the entire window instead of the start button
- Keep "Start Game" button in foreground atop the logo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6ba875c4832eb666c1082f50eaa9