### PR TITLE
Restore initial splash screen with login button

### DIFF
--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -1,5 +1,6 @@
-from pathlib import Path
-from PyQt6.QtWidgets import QWidget, QPushButton, QVBoxLayout
+import os
+from PyQt6.QtWidgets import QWidget, QLabel, QPushButton, QVBoxLayout
+from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt
 
 from ui.login_window import LoginWindow
@@ -11,28 +12,25 @@ class SplashScreen(QWidget):
         super().__init__()
         self.setWindowTitle("UBL")
 
-        self.setObjectName("splash_screen")
-
         layout = QVBoxLayout()
         layout.addStretch()
 
-        logo_path = Path(__file__).resolve().parents[1] / "logo" / "UBL.png"
-        logo_url = logo_path.as_posix()
-        self.setStyleSheet(
-            f"""
-            #splash_screen {{
-                border-image: url('{logo_url}') 0 0 0 0 stretch stretch;
-            }}
-            """
+        logo_label = QLabel()
+        logo_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "logo",
+            "UBL.png",
         )
+        logo_label.setPixmap(QPixmap(logo_path))
+        logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(logo_label)
 
-        self.start_button = QPushButton("Start Game")
-        self.start_button.setFixedSize(200, 60)
-        self.start_button.setStyleSheet("font-size: 20px;")
-        self.start_button.clicked.connect(self.open_login)
-        layout.addWidget(self.start_button, alignment=Qt.AlignmentFlag.AlignHCenter)
+        layout.addStretch()
 
-        layout.setContentsMargins(0, 0, 0, 150)
+        self.login_button = QPushButton("Login")
+        self.login_button.clicked.connect(self.open_login)
+        layout.addWidget(self.login_button, alignment=Qt.AlignmentFlag.AlignCenter)
+
         self.setLayout(layout)
         self.login_window = None
 


### PR DESCRIPTION
## Summary
- Revert splash screen to original implementation with QLabel logo and Login button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a6d4e7a40832e9c94fd919902c34f