### PR TITLE
Show dashboard fullscreen and hide splash screen

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -74,9 +74,7 @@ class LoginWindow(QWidget):
             QMessageBox.warning(self, "Error", "Unrecognized role.")
             return
 
-        self.dashboard.resize(1000, 800)
-
-        self.dashboard.show()
+        self.dashboard.showFullScreen()
         self.close()
 
 if __name__ == "__main__":

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -35,7 +35,7 @@ class SplashScreen(QWidget):
         self.login_window = None
 
     def open_login(self):
-        """Show the login window and close the splash screen."""
+        """Show the login window and hide the splash screen."""
         self.login_window = LoginWindow()
         self.login_window.show()
-        self.close()
+        self.hide()


### PR DESCRIPTION
## Summary
- Keep splash screen instance alive by hiding instead of closing when opening the login window.
- Launch dashboards in full screen on login and close the login window afterward.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a703d66d0832e9f38844076449bd4