### PR TITLE
feat(ui): adjust splash screen button placement

### DIFF
--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -31,6 +31,10 @@ class SplashScreen(QWidget):
         self.login_button.clicked.connect(self.open_login)
         layout.addWidget(self.login_button, alignment=Qt.AlignmentFlag.AlignCenter)
 
+        # Add a stretch below the login button to push it upward for a
+        # more balanced appearance on the splash screen.
+        layout.addStretch()
+
         self.setLayout(layout)
         self.login_window = None
 


### PR DESCRIPTION
## Summary
- Add bottom stretch in splash screen layout to position login button higher for improved balance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a72d95294832eaf2627cb69447356