### PR TITLE
Show splash screen maximized instead of full screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from ui.splash_screen import SplashScreen
 def main():
     app = QApplication(sys.argv)
     splash = SplashScreen()
-    splash.showFullScreen()
+    splash.showMaximized()
     sys.exit(app.exec())
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Display the splash screen maximized to keep standard window decorations

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a7ac2a578832e8cefb9676dd6cad0