### PR TITLE
Show dashboards maximized instead of full screen

### DIFF
--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -74,7 +74,9 @@ class LoginWindow(QWidget):
             QMessageBox.warning(self, "Error", "Unrecognized role.")
             return
 
-        self.dashboard.showFullScreen()
+        # Display the dashboard in a maximized window so standard window
+        # controls (minimize, maximize, close) are available.
+        self.dashboard.showMaximized()
         self.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Display admin and owner dashboards in maximized windows so standard window controls are available.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a7bb2d3a0832e87bbbd92916d46c2