### PR TITLE
Add color picker and hex validation to team settings dialog

### DIFF
--- a/ui/team_settings_dialog.py
+++ b/ui/team_settings_dialog.py
@@ -23,12 +23,28 @@ class TeamSettingsDialog(QDialog):
 
         # Colors
         color_row = QHBoxLayout()
+        from PyQt6.QtCore import QRegularExpression
+        from PyQt6.QtGui import QRegularExpressionValidator
+
+        hex_regex = QRegularExpression(r"#[0-9A-Fa-f]{6}")
+        validator = QRegularExpressionValidator(hex_regex, self)
+
         color_row.addWidget(QLabel("Primary Color:"))
         self.primary_edit = QLineEdit(team.primary_color)
+        self.primary_edit.setValidator(validator)
         color_row.addWidget(self.primary_edit)
+        primary_btn = QPushButton("Choose")
+        primary_btn.clicked.connect(lambda: self.choose_color(self.primary_edit))
+        color_row.addWidget(primary_btn)
+
         color_row.addWidget(QLabel("Secondary Color:"))
         self.secondary_edit = QLineEdit(team.secondary_color)
+        self.secondary_edit.setValidator(validator)
         color_row.addWidget(self.secondary_edit)
+        secondary_btn = QPushButton("Choose")
+        secondary_btn.clicked.connect(lambda: self.choose_color(self.secondary_edit))
+        color_row.addWidget(secondary_btn)
+
         layout.addLayout(color_row)
 
         # Stadium selection
@@ -53,10 +69,22 @@ class TeamSettingsDialog(QDialog):
 
         self.setLayout(layout)
 
+    def choose_color(self, edit):
+        """Open a color dialog and set the selected color on the given line edit."""
+        from PyQt6.QtWidgets import QColorDialog
+        from PyQt6.QtGui import QColor
+
+        current = edit.text() or "#ffffff"
+        color = QColorDialog.getColor(QColor(current), self, "Select Color")
+        if color.isValid():
+            edit.setText(color.name())
+
     def get_settings(self):
+        primary = self.primary_edit.text().strip()
+        secondary = self.secondary_edit.text().strip()
         return {
-            "primary_color": self.primary_edit.text().strip(),
-            "secondary_color": self.secondary_edit.text().strip(),
+            "primary_color": primary if self.primary_edit.hasAcceptableInput() else "",
+            "secondary_color": secondary if self.secondary_edit.hasAcceptableInput() else "",
             "stadium": self.stadium_combo.currentText(),
         }
 


### PR DESCRIPTION
## Summary
- Replace color text fields with line edits powered by a color picker and hex validator
- Ensure team color selections return validated hex strings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a7ed2c4b0832eb5442ff173bd7cc4