### PR TITLE
Validate team color codes before saving to CSV

### DIFF
--- a/tests/test_team_loader.py
+++ b/tests/test_team_loader.py
@@ -1,0 +1,29 @@
+import pytest
+from utils.team_loader import load_teams, save_team_settings
+
+
+def _create_team_file(tmp_path):
+    file = tmp_path / "teams.csv"
+    file.write_text(
+        "team_id,name,city,abbreviation,division,stadium,primary_color,secondary_color,owner_id\n"
+        "1,Team,City,TC,DIV,Stadium,#FFFFFF,#000000,owner\n"
+    )
+    return file
+
+
+def test_sanitize_hex_colors(tmp_path):
+    team_file = _create_team_file(tmp_path)
+    team = load_teams(str(team_file))[0]
+    team.primary_color = "123abc"  # missing '#', lowercase
+    save_team_settings(team, str(team_file))
+
+    updated = load_teams(str(team_file))[0]
+    assert updated.primary_color == "#123ABC"
+
+
+def test_invalid_hex_color_raises(tmp_path):
+    team_file = _create_team_file(tmp_path)
+    team = load_teams(str(team_file))[0]
+    team.secondary_color = "ZZZZZZ"  # invalid characters
+    with pytest.raises(ValueError):
+        save_team_settings(team, str(team_file))

--- a/utils/team_loader.py
+++ b/utils/team_loader.py
@@ -1,4 +1,5 @@
 import csv
+import re
 from models.team import Team
 
 def load_teams(file_path="data/teams.csv"):
@@ -29,14 +30,29 @@ def save_team_settings(team: Team, file_path="data/teams.csv") -> None:
     other information remains unchanged.
     """
 
+    def _sanitize_color(value: str, field: str) -> str:
+        """Return a normalized hex color or raise ``ValueError``.
+
+        The function ensures the color string begins with ``#`` and matches the
+        ``#RRGGBB`` or ``#RGB`` formats. If the value cannot be normalized into a
+        valid hex color a descriptive ``ValueError`` is raised.
+        """
+
+        value = value.strip()
+        if not value.startswith("#"):
+            value = f"#{value}"
+        if re.fullmatch(r"#(?:[0-9a-fA-F]{3}){1,2}$", value):
+            return value.upper()
+        raise ValueError(f"Invalid hex color for {field}: {value}")
+
     teams = []
     with open(file_path, mode="r", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             if row["team_id"] == team.team_id:
                 row["stadium"] = team.stadium
-                row["primary_color"] = team.primary_color
-                row["secondary_color"] = team.secondary_color
+                row["primary_color"] = _sanitize_color(team.primary_color, "primary_color")
+                row["secondary_color"] = _sanitize_color(team.secondary_color, "secondary_color")
             teams.append(row)
 
     fieldnames = [


### PR DESCRIPTION
## Summary
- normalize and validate team color hex values before saving
- add tests for color validation and sanitation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a86fa86ac832ea4ec8de2cddf8b64