### PR TITLE
Preserve admin account when clearing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ Tests are located in the `tests/` directory and can be executed with:
 pytest
 ```
 
+### Default Admin Credentials
+When a new league is created or user accounts are cleared, the system rewrites
+`data/users.txt` to contain a single administrator account. Use these fallback
+credentials to log in after a reset:
+
+```
+username: admin
+password: pass
+```
+

--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -129,5 +129,6 @@ def test_create_league_clears_users_and_rosters(tmp_path, monkeypatch):
 
     create_league(str(base_dir), divisions, "Test League")
 
-    assert not users_file.exists()
+    assert users_file.exists()
+    assert users_file.read_text() == "admin,pass,admin,\n"
     assert not stray.exists()

--- a/utils/user_manager.py
+++ b/utils/user_manager.py
@@ -121,6 +121,24 @@ def update_user(
 
 
 def clear_users(file_path: str = "data/users.txt") -> None:
-    """Remove all user accounts by deleting the users file if it exists."""
+    """Reset the users file to contain only the admin account.
+
+    If ``file_path`` exists, any existing users are discarded and the file is
+    rewritten with only the line beginning with ``"admin,"``. If no such line
+    exists, a default admin account of ``admin,pass,admin,`` is written.
+    The directory for ``file_path`` is created if it does not already exist.
+    """
+    admin_line = None
     if os.path.exists(file_path):
-        os.remove(file_path)
+        with open(file_path, "r") as f:
+            for line in f:
+                if line.startswith("admin,"):
+                    admin_line = line.strip()
+                    break
+
+    if admin_line is None:
+        admin_line = "admin,pass,admin,"
+
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(admin_line.rstrip("\n") + "\n")


### PR DESCRIPTION
## Summary
- Keep an admin record when clearing users so a default admin account always exists
- Add league creation test to verify admin account remains after reset
- Document fallback admin credentials in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a941ff938832ebc6b56eadef5b053