### PR TITLE
feat: add team logo generation

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -68,6 +68,10 @@ class AdminDashboard(QWidget):
         self.edit_user_button.clicked.connect(self.open_edit_user)
         button_layout.addWidget(self.edit_user_button, alignment=Qt.AlignmentFlag.AlignHCenter)
 
+        self.generate_logos_button = QPushButton("Generate Team Logos")
+        self.generate_logos_button.clicked.connect(self.generate_team_logos)
+        button_layout.addWidget(self.generate_logos_button, alignment=Qt.AlignmentFlag.AlignHCenter)
+
         layout.addLayout(button_layout)
         layout.addStretch()
 
@@ -161,6 +165,18 @@ class AdminDashboard(QWidget):
         layout.addLayout(btn_layout)
         dialog.setLayout(layout)
         dialog.exec()
+
+    def generate_team_logos(self):
+        try:
+            from utils.logo_generator import generate_team_logos
+            out_dir = generate_team_logos()
+            QMessageBox.information(
+                self,
+                "Logos Generated",
+                f"Team logos created in: {out_dir}",
+            )
+        except Exception as e:
+            QMessageBox.warning(self, "Error", f"Failed to generate logos: {e}")
 
     def open_add_user(self):
         dialog = QDialog(self)

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover - fallback for environments without PyQt
         def quit():
             pass
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QFont
+from PyQt6.QtGui import QFont, QPixmap
 
 from ui.lineup_editor import LineupEditor
 from ui.pitching_editor import PitchingEditor
@@ -107,6 +107,20 @@ class OwnerDashboard(QWidget):
         league_menu.addAction("Standings")
         league_menu.addAction("Schedule")
         main.setMenuBar(menubar)
+
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        logo_path = os.path.join(base_dir, "logo", "teams", f"{team_id.lower()}.png")
+        if os.path.exists(logo_path):
+            logo_label = QLabel()
+            pix = QPixmap(logo_path).scaled(
+                128,
+                128,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            logo_label.setPixmap(pix)
+            logo_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            main.addWidget(logo_label)
 
         welcome = QLabel(f"Welcome, Owner of {team_id}!")
         welcome.setFont(bold)

--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -1,0 +1,46 @@
+"""Utilities for generating team logos.
+
+Creates simple team logos using the :mod:`images.auto_logo` module. Logos are
+written to ``logo/teams`` relative to the repository root and named after the
+team's ID (lower‑cased).
+"""
+from __future__ import annotations
+
+import os
+from typing import List
+
+from images.auto_logo import TeamSpec, batch_generate
+from utils.team_loader import load_teams
+
+
+def generate_team_logos(out_dir: str | None = None, size: int = 512) -> str:
+    """Generate logos for all teams and return the output directory.
+
+    Parameters
+    ----------
+    out_dir:
+        Optional output directory. Defaults to ``logo/teams`` relative to the
+        project root.
+    size:
+        Pixel size for the generated square logos.
+    """
+
+    teams = load_teams("data/teams.csv")
+    specs: List[TeamSpec] = []
+    for t in teams:
+        specs.append(
+            TeamSpec(
+                location=t.city,
+                mascot=t.name,
+                primary=t.primary_color,
+                secondary=t.secondary_color,
+                abbrev=t.team_id,
+            )
+        )
+
+    if out_dir is None:
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        out_dir = os.path.join(base_dir, "logo", "teams")
+    os.makedirs(out_dir, exist_ok=True)
+    batch_generate(specs, out_dir=out_dir, size=size)
+    return out_dir


### PR DESCRIPTION
## Summary
- add utility to generate logos for all teams
- wire generation feature into admin dashboard
- show team logo on owner dashboard when available

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a999aa058832ea84f74824be2e74b