### PR TITLE
Add exhibition game simulation dialog

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 from ui.team_entry_dialog import TeamEntryDialog
+from ui.exhibition_game_dialog import ExhibitionGameDialog
 from utils.trade_utils import load_trades, save_trade
 from utils.news_logger import log_news_event
 from utils.roster_loader import load_roster
@@ -22,9 +23,6 @@ from utils.player_loader import load_players_from_csv
 from utils.team_loader import load_teams
 from utils.user_manager import add_user, load_users, update_user
 from models.trade import Trade
-from logic.simulation import GameSimulation, TeamState
-from models.pitcher import Pitcher
-from logic.pbini_loader import load_pbini
 import csv
 import os
 from logic.league_creator import create_league
@@ -186,82 +184,7 @@ class AdminDashboard(QWidget):
             QMessageBox.warning(self, "Error", f"Failed to generate logos: {e}")
 
     def open_exhibition_dialog(self):
-        dialog = QDialog(self)
-        dialog.setWindowTitle("Simulate Exhibition Game")
-
-        layout = QVBoxLayout()
-
-        team1_combo = QComboBox()
-        team2_combo = QComboBox()
-
-        data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
-        teams = load_teams(os.path.join(data_dir, "teams.csv"))
-        for t in teams:
-            team1_combo.addItem(f"{t.name} ({t.team_id})", userData=t.team_id)
-            team2_combo.addItem(f"{t.name} ({t.team_id})", userData=t.team_id)
-
-        layout.addWidget(QLabel("Home Team:"))
-        layout.addWidget(team1_combo)
-        layout.addWidget(QLabel("Away Team:"))
-        layout.addWidget(team2_combo)
-
-        simulate_btn = QPushButton("Simulate")
-        simulate_btn.setEnabled(False)
-        layout.addWidget(simulate_btn, alignment=Qt.AlignmentFlag.AlignHCenter)
-
-        def update_button():
-            simulate_btn.setEnabled(
-                team1_combo.currentData() is not None
-                and team2_combo.currentData() is not None
-                and team1_combo.currentData() != team2_combo.currentData()
-            )
-
-        team1_combo.currentIndexChanged.connect(update_button)
-        team2_combo.currentIndexChanged.connect(update_button)
-        update_button()
-
-        def simulate():
-            home_id = team1_combo.currentData()
-            away_id = team2_combo.currentData()
-            try:
-                players = {
-                    p.player_id: p
-                    for p in load_players_from_csv(os.path.join(data_dir, "players.csv"))
-                }
-                home_roster = load_roster(home_id, os.path.join(data_dir, "rosters"))
-                away_roster = load_roster(away_id, os.path.join(data_dir, "rosters"))
-
-                def build_state(roster):
-                    lineup = []
-                    bench = []
-                    pitchers = []
-                    for pid in roster.act:
-                        player = players.get(pid)
-                        if not player:
-                            continue
-                        if isinstance(player, Pitcher):
-                            pitchers.append(player)
-                        elif len(lineup) < 9:
-                            lineup.append(player)
-                        else:
-                            bench.append(player)
-                    return TeamState(lineup=lineup, bench=bench, pitchers=pitchers)
-
-                home_state = build_state(home_roster)
-                away_state = build_state(away_roster)
-                cfg = load_pbini(os.path.join(os.path.dirname(__file__), "..", "logic", "PBINI.txt"))
-                sim = GameSimulation(home_state, away_state, cfg)
-                sim.simulate_game()
-                QMessageBox.information(
-                    dialog,
-                    "Simulation Complete",
-                    f"Exhibition game between {home_id} and {away_id} simulated.",
-                )
-            except Exception as e:
-                QMessageBox.warning(dialog, "Error", f"Failed to simulate: {e}")
-
-        simulate_btn.clicked.connect(simulate)
-        dialog.setLayout(layout)
+        dialog = ExhibitionGameDialog(self)
         dialog.exec()
 
     def open_add_user(self):

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -1,0 +1,148 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QComboBox,
+    QPushButton,
+    QMessageBox,
+    QPlainTextEdit,
+)
+from PyQt6.QtCore import Qt
+from typing import Dict
+import os
+
+from utils.team_loader import load_teams
+from utils.player_loader import load_players_from_csv
+from utils.roster_loader import load_roster
+from logic.simulation import GameSimulation, TeamState
+from models.pitcher import Pitcher
+from logic.pbini_loader import load_pbini
+
+
+class ExhibitionGameDialog(QDialog):
+    """Dialog to select teams and simulate an exhibition game."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Simulate Exhibition Game")
+
+        layout = QVBoxLayout()
+
+        self.home_combo = QComboBox()
+        self.away_combo = QComboBox()
+
+        data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
+        teams = load_teams(os.path.join(data_dir, "teams.csv"))
+        self._teams: Dict[str, str] = {}
+        for t in teams:
+            label = f"{t.name} ({t.team_id})"
+            self.home_combo.addItem(label, userData=t.team_id)
+            self.away_combo.addItem(label, userData=t.team_id)
+            self._teams[t.team_id] = t.name
+
+        layout.addWidget(QLabel("Home Team:"))
+        layout.addWidget(self.home_combo)
+        layout.addWidget(QLabel("Away Team:"))
+        layout.addWidget(self.away_combo)
+
+        self.simulate_btn = QPushButton("Simulate")
+        self.simulate_btn.setEnabled(False)
+        layout.addWidget(self.simulate_btn, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        self.box_score = QPlainTextEdit()
+        self.box_score.setReadOnly(True)
+        layout.addWidget(self.box_score)
+
+        self.setLayout(layout)
+
+        self.home_combo.currentIndexChanged.connect(self._update_button)
+        self.away_combo.currentIndexChanged.connect(self._update_button)
+        self.simulate_btn.clicked.connect(self._simulate)
+        self._data_dir = data_dir
+        self._update_button()
+
+    def _update_button(self) -> None:
+        self.simulate_btn.setEnabled(
+            self.home_combo.currentData() is not None
+            and self.away_combo.currentData() is not None
+            and self.home_combo.currentData() != self.away_combo.currentData()
+        )
+
+    def _build_state(self, team_id: str) -> TeamState:
+        players = {
+            p.player_id: p
+            for p in load_players_from_csv(os.path.join(self._data_dir, "players.csv"))
+        }
+        roster = load_roster(team_id, os.path.join(self._data_dir, "rosters"))
+
+        lineup = []
+        bench = []
+        pitchers = []
+        for pid in roster.act:
+            player = players.get(pid)
+            if not player:
+                continue
+            if isinstance(player, Pitcher):
+                pitchers.append(player)
+            elif len(lineup) < 9:
+                lineup.append(player)
+            else:
+                bench.append(player)
+
+        if len(lineup) < 9:
+            raise ValueError(f"Team {team_id} does not have enough position players")
+        if not pitchers:
+            raise ValueError(f"Team {team_id} does not have any pitchers")
+
+        return TeamState(lineup=lineup, bench=bench, pitchers=pitchers)
+
+    def _simulate(self) -> None:
+        home_id = self.home_combo.currentData()
+        away_id = self.away_combo.currentData()
+        if home_id is None or away_id is None:
+            return
+        try:
+            home_state = self._build_state(home_id)
+            away_state = self._build_state(away_id)
+            cfg = load_pbini(os.path.join(os.path.dirname(__file__), "..", "logic", "PBINI.txt"))
+            sim = GameSimulation(home_state, away_state, cfg)
+            sim.simulate_game()
+            text = self._format_box_score(home_id, home_state, away_id, away_state)
+            self.box_score.setPlainText(text)
+        except FileNotFoundError as e:
+            QMessageBox.warning(self, "Missing Data", str(e))
+        except ValueError as e:
+            QMessageBox.warning(self, "Missing Data", str(e))
+        except Exception as e:
+            QMessageBox.warning(self, "Error", f"Failed to simulate: {e}")
+
+    def _format_box_score(
+        self,
+        home_id: str,
+        home_state: TeamState,
+        away_id: str,
+        away_state: TeamState,
+    ) -> str:
+        lines = [
+            f"Exhibition Game: {self._teams.get(home_id, home_id)} vs {self._teams.get(away_id, away_id)}",
+            "",
+        ]
+
+        def team_section(label: str, state: TeamState) -> None:
+            lines.append(label)
+            lines.append("BATTING")
+            for bs in state.lineup_stats.values():
+                p = bs.player
+                lines.append(
+                    f"{p.first_name} {p.last_name}: {bs.hits}-{bs.at_bats}, SB {bs.steals}"
+                )
+            if state.pitcher_stats:
+                lines.append("PITCHING")
+                for ps in state.pitcher_stats.values():
+                    p = ps.player
+                    lines.append(f"{p.first_name} {p.last_name}: {ps.pitches_thrown} pitches")
+            lines.append("")
+
+        team_section(f"Away - {self._teams.get(away_id, away_id)}", away_state)
+        team_section(f"Home - {self._teams.get(home_id, home_id)}", home_state)
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Introduce `ExhibitionGameDialog` with team selectors, a simulate button, box score output, and missing roster handling.
- Wire AdminDashboard's "Simulate Exhibition Game" button to the new dialog.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9e09d5a8832e8b6ada69db71d286