### PR TITLE
Add default lineup builder and team state helper

### DIFF
--- a/tests/test_lineup_loader.py
+++ b/tests/test_lineup_loader.py
@@ -1,0 +1,46 @@
+import pytest
+
+from utils.lineup_loader import build_default_game_state
+from utils.player_loader import load_players_from_csv
+from utils.roster_loader import load_roster
+from utils.pitcher_role import get_role
+
+
+def _expected_state(team_id: str):
+    players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
+    roster = load_roster(team_id)
+
+    hitters = []
+    pitchers = []
+    for pid in roster.act:
+        player = players.get(pid)
+        if not player:
+            continue
+        role = get_role(player)
+        if role in {"SP", "RP"}:
+            pitchers.append(player)
+        else:
+            hitters.append(player)
+
+    hitters.sort(key=lambda p: p.ph, reverse=True)
+    lineup = hitters[:9]
+    bench = hitters[9:]
+
+    starters = [p for p in pitchers if get_role(p) == "SP"]
+    if starters:
+        starter = max(starters, key=lambda p: p.endurance)
+    else:
+        starter = max(pitchers, key=lambda p: p.endurance)
+    expected_pitchers = [starter] + [p for p in pitchers if p.player_id != starter.player_id]
+
+    return lineup, bench, expected_pitchers
+
+
+def test_build_default_game_state_creates_expected_lineup():
+    team_id = "ABU"
+    state = build_default_game_state(team_id)
+    lineup, bench, pitchers = _expected_state(team_id)
+
+    assert [p.player_id for p in state.lineup] == [p.player_id for p in lineup]
+    assert [p.player_id for p in state.bench] == [p.player_id for p in bench]
+    assert [p.player_id for p in state.pitchers] == [p.player_id for p in pitchers]

--- a/utils/lineup_loader.py
+++ b/utils/lineup_loader.py
@@ -1,6 +1,13 @@
 import csv
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Iterable
+
+from logic.simulation import TeamState
+from models.player import Player
+from models.pitcher import Pitcher
+from .player_loader import load_players_from_csv
+from .roster_loader import load_roster
+from .pitcher_role import get_role
 
 
 def load_lineup(team_id: str, vs: str = "lhp", lineup_dir: str = "data/lineups") -> List[Tuple[str, str]]:
@@ -24,3 +31,78 @@ def load_lineup(team_id: str, vs: str = "lhp", lineup_dir: str = "data/lineups")
             position = row.get("position", "").strip()
             lineup.append((player_id, position))
     return lineup
+
+
+def _separate_players(players: Iterable[Player]) -> Tuple[List[Player], List[Pitcher]]:
+    """Return hitters and pitchers from ``players``.
+
+    Pitchers are identified using :func:`utils.pitcher_role.get_role`.  Players
+    for which ``get_role`` returns ``"SP"`` or ``"RP"`` are treated as
+    pitchers, everything else is considered a position player.
+    """
+
+    hitters: List[Player] = []
+    pitchers: List[Pitcher] = []
+    for p in players:
+        role = get_role(p)
+        if role in {"SP", "RP"}:
+            pitchers.append(p)  # type: ignore[arg-type]
+        else:
+            hitters.append(p)
+    return hitters, pitchers
+
+
+def _build_default_lists(team_id: str, players_file: str, roster_dir: str) -> Tuple[List[Player], List[Player], List[Pitcher]]:
+    """Return ``(lineup, bench, pitchers)`` for ``team_id``.
+
+    The active roster is loaded from ``roster_dir`` and players are resolved via
+    ``players_file``.  Nine position players are selected for the lineup based
+    on descending ``ph`` (power hitting) rating.  Pitchers are ordered with a
+    single starter first followed by the remaining bullpen arms.
+    """
+
+    all_players = {
+        p.player_id: p for p in load_players_from_csv(players_file)
+    }
+    roster = load_roster(team_id, roster_dir)
+
+    active = [all_players.get(pid) for pid in roster.act]
+    active = [p for p in active if p is not None]
+
+    hitters, pitchers = _separate_players(active)
+
+    hitters.sort(key=lambda p: getattr(p, "ph", 0), reverse=True)
+    lineup = hitters[:9]
+    bench = hitters[9:]
+
+    starter_candidates = [p for p in pitchers if get_role(p) == "SP"]
+    if starter_candidates:
+        starter = max(starter_candidates, key=lambda p: getattr(p, "endurance", 0))
+        bullpen = [p for p in pitchers if p is not starter]
+        pitchers_sorted = [starter] + bullpen
+    else:
+        pitchers.sort(key=lambda p: getattr(p, "endurance", 0), reverse=True)
+        pitchers_sorted = pitchers
+
+    return lineup, bench, pitchers_sorted
+
+
+def build_default_game_state(
+    team_id: str,
+    players_file: str = "data/players.csv",
+    roster_dir: str = "data/rosters",
+) -> TeamState:
+    """Return a :class:`~logic.simulation.TeamState` for ``team_id``.
+
+    The state uses nine best hitters for the lineup, remaining hitters as the
+    bench and pitchers ordered with a starter first followed by the bullpen.
+    """
+
+    lineup, bench, pitchers = _build_default_lists(team_id, players_file, roster_dir)
+
+    if len(lineup) < 9:
+        raise ValueError(f"Team {team_id} does not have enough position players")
+    if not pitchers:
+        raise ValueError(f"Team {team_id} does not have any pitchers")
+
+    return TeamState(lineup=lineup, bench=bench, pitchers=pitchers)


### PR DESCRIPTION
## Summary
- add utilities to build a lineup and pitcher list from a team's roster
- expose `build_default_game_state` returning a populated `TeamState`
- test default lineup construction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9f1cab88832e968a68af1727771e