### PR TITLE
Integrate defensive decision logic with simulation and UI

### DIFF
--- a/logic/defensive_manager.py
+++ b/logic/defensive_manager.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from .pbini_loader import load_pbini
+
+
+class DefensiveManager:
+    """Handle defensive strategy decisions based on PB.INI configuration."""
+
+    def __init__(self, pbini: Dict[str, Dict[str, Any]], rng: random.Random | None = None) -> None:
+        self.config = pbini.get("PlayBalance", {})
+        self.rng = rng or random.Random()
+
+    @classmethod
+    def from_file(
+        cls, path: str | Path, rng: random.Random | None = None
+    ) -> "DefensiveManager":
+        pbini = load_pbini(path)
+        return cls(pbini, rng)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _roll(self, chance: float) -> bool:
+        """Return True with ``chance`` percent probability."""
+        chance = max(0.0, min(100.0, chance))
+        if chance <= 0:
+            return False
+        if chance >= 100:
+            return True
+        return self.rng.random() < chance / 100.0
+
+    # ------------------------------------------------------------------
+    # Defensive decisions
+    # ------------------------------------------------------------------
+    def maybe_charge_bunt(self) -> bool:
+        cfg = self.config
+        base = cfg.get("chargeChanceBaseThird", 0) + cfg.get(
+            "chargeChanceSacChanceAdjust", 0
+        )
+        chance = base * cfg.get("defManChargeChancePct", 100) / 100.0
+        return self._roll(chance)
+
+    def maybe_hold_runner(self, runner_speed: int) -> bool:
+        cfg = self.config
+        chance = cfg.get("holdChanceBase", 0)
+        if runner_speed >= cfg.get("holdChanceMinRunnerSpeed", 9999):
+            chance += cfg.get("holdChanceAdjust", 0)
+        return self._roll(chance)
+
+    def maybe_pickoff(self, lead: int = 0, pitches_since: int = 0) -> bool:
+        cfg = self.config
+        chance = cfg.get("pickoffChanceBase", 0)
+        chance += cfg.get("pickoffChanceStealChanceAdjust", 0)
+        chance += cfg.get("pickoffChanceLeadMult", 0) * lead
+        chance += cfg.get("pickoffChancePitchesMult", 0) * pitches_since
+        return self._roll(chance)
+
+    def maybe_pitch_out(
+        self,
+        steal_chance: int = 0,
+        hit_run_chance: int = 0,
+        ball_count: int = 0,
+        inning: int = 1,
+        is_home_team: bool = False,
+    ) -> bool:
+        cfg = self.config
+        if (
+            steal_chance < cfg.get("pitchOutChanceStealThresh", 0)
+            and hit_run_chance < cfg.get("pitchOutChanceHitRunThresh", 0)
+        ):
+            return False
+        chance = cfg.get("pitchOutChanceBase", 0)
+        if ball_count == 0:
+            chance += cfg.get("pitchOutChanceBall0Adjust", 0)
+        elif ball_count == 1:
+            chance += cfg.get("pitchOutChanceBall1Adjust", 0)
+        elif ball_count == 2:
+            chance += cfg.get("pitchOutChanceBall2Adjust", 0)
+        else:
+            chance += cfg.get("pitchOutChanceBall3Adjust", 0)
+        if inning == 8:
+            chance += cfg.get("pitchOutChanceInn8Adjust", 0)
+        elif inning >= 9:
+            chance += cfg.get("pitchOutChanceInn9Adjust", 0)
+        if is_home_team:
+            chance += cfg.get("pitchOutChanceHomeAdjust", 0)
+        return self._roll(chance)
+
+    def maybe_pitch_around(self, inning: int = 1) -> Tuple[bool, bool]:
+        cfg = self.config
+        if inning <= cfg.get("pitchAroundChanceNoInn", 0):
+            return False, False
+        chance = cfg.get("pitchAroundChanceBase", 0)
+        if inning in (7, 8):
+            chance += cfg.get("pitchAroundChanceInn7Adjust", 0)
+        elif inning >= 9:
+            chance += cfg.get("pitchAroundChanceInn9Adjust", 0)
+        pitch_around = self._roll(chance)
+        ibb = False
+        if pitch_around:
+            ibb_chance = chance * cfg.get("defManPitchAroundToIBBPct", 0) / 100.0
+            ibb = self._roll(ibb_chance)
+        return pitch_around, ibb
+
+    # ------------------------------------------------------------------
+    # Field positioning
+    # ------------------------------------------------------------------
+    def set_field_positions(self) -> Dict[str, Dict[str, tuple]]:
+        cfg = self.config
+        situations = ["normal", "guardLines"]
+        fielders = ["1B", "2B", "SS", "3B"]
+        positions: Dict[str, Dict[str, tuple]] = {}
+        for sit in situations:
+            sit_dict: Dict[str, tuple] = {}
+            for f in fielders:
+                dist_key = f"{sit}Pos{f}Dist"
+                angle_key = f"{sit}Pos{f}Angle"
+                dist = cfg.get(dist_key)
+                angle = cfg.get(angle_key)
+                if dist is not None and angle is not None:
+                    sit_dict[f] = (dist, angle)
+            if sit_dict:
+                positions[sit] = sit_dict
+        return positions
+
+
+__all__ = ["DefensiveManager"]

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -1,0 +1,79 @@
+from logic.defensive_manager import DefensiveManager
+
+import random
+
+
+class MockRandom(random.Random):
+    def __init__(self, values):
+        super().__init__()
+        self.values = list(values)
+
+    def random(self):  # type: ignore[override]
+        return self.values.pop(0)
+
+
+def make_cfg(**entries):
+    return {"PlayBalance": entries}
+
+
+def test_charge_bunt_chance():
+    cfg = make_cfg(
+        chargeChanceBaseThird=20,
+        chargeChanceSacChanceAdjust=10,
+        defManChargeChancePct=50,
+    )
+    rng = MockRandom([0.1, 0.2])
+    dm = DefensiveManager(cfg, rng)
+    assert dm.maybe_charge_bunt() is True
+    assert dm.maybe_charge_bunt() is False
+
+
+def test_hold_runner_chance():
+    cfg = make_cfg(
+        holdChanceBase=10,
+        holdChanceAdjust=50,
+        holdChanceMinRunnerSpeed=30,
+    )
+    dm = DefensiveManager(cfg, MockRandom([0.5]))
+    assert dm.maybe_hold_runner(35) is True  # 60% chance
+    dm2 = DefensiveManager(cfg, MockRandom([0.5]))
+    assert dm2.maybe_hold_runner(20) is False  # 10% chance
+
+
+def test_pickoff_chance():
+    cfg = make_cfg(
+        pickoffChanceBase=10,
+        pickoffChanceStealChanceAdjust=10,
+        pickoffChanceLeadMult=5,
+    )
+    rng = MockRandom([0.25, 0.35])
+    dm = DefensiveManager(cfg, rng)
+    assert dm.maybe_pickoff(lead=2) is True
+    assert dm.maybe_pickoff(lead=2) is False
+
+
+def test_pitch_out_chance():
+    cfg = make_cfg(
+        pitchOutChanceStealThresh=10,
+        pitchOutChanceBase=20,
+        pitchOutChanceBall0Adjust=5,
+    )
+    rng = MockRandom([0.2, 0.3])
+    dm = DefensiveManager(cfg, rng)
+    assert dm.maybe_pitch_out(steal_chance=15, ball_count=0) is True
+    assert dm.maybe_pitch_out(steal_chance=15, ball_count=0) is False
+
+
+def test_pitch_around_chance():
+    cfg = make_cfg(
+        pitchAroundChanceNoInn=0,
+        pitchAroundChanceBase=30,
+        pitchAroundChanceInn7Adjust=5,
+        defManPitchAroundToIBBPct=50,
+    )
+    rng = MockRandom([0.2, 0.1, 0.4])
+    dm = DefensiveManager(cfg, rng)
+    pa, ibb = dm.maybe_pitch_around(inning=7)
+    assert pa is True and ibb is True
+    pa2, ibb2 = dm.maybe_pitch_around(inning=7)
+    assert pa2 is False and ibb2 is False

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -109,6 +109,13 @@ class ExhibitionGameDialog(QDialog):
             sim.simulate_game()
             box = generate_boxscore(home_state, away_state)
             text = self._format_box_score(home_id, away_id, box)
+            if sim.debug_log:
+                text += "\n\nDefensive Log:\n" + "\n".join(sim.debug_log)
+            positions = sim.defense.set_field_positions()
+            if positions:
+                text += "\n\nField Positions:\n"
+                for sit, pos in positions.items():
+                    text += f"{sit}: {pos}\n"
             self.box_score.setPlainText(text)
         except FileNotFoundError as e:
             QMessageBox.warning(self, "Missing Data", str(e))


### PR DESCRIPTION
## Summary
- add DefensiveManager for defensive strategy chances and positioning
- wire GameSimulation to invoke defensive decisions and record debug logs
- surface defensive log and field positions in exhibition dialog
- test defensive manager chance calculations with deterministic RNG

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa334c1a4832ea1e66e5639f2ca2a