### PR TITLE
Refactor play balance configuration usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ UBL (Ultimate Baseball League) Simulation is a Python project that models a smal
 - **Game simulation:** `logic/simulation.py` provides a minimal engine for at-bats, pitching changes and base running.
 - **Data files:** example data lives in the `data/` directory including rosters, lineups and configuration values.
 
+### Play balance configuration
+
+Strategy behaviour in the simulation is driven by values from the
+`PlayBalance` section of the historical *PB.INI* file.  The configuration is
+loaded into a dedicated :class:`PlayBalanceConfig` dataclass
+(`logic/playbalance_config.py`) which exposes the entries as attributes with
+safe defaults.  The managers and `GameSimulation` consume this object instead
+of raw dictionaries.
+
+For tests and experimentation a helper factory is provided in
+`tests/util/pbini_factory.py` which can create minimal configurations:
+
+```python
+from tests.util.pbini_factory import make_cfg
+cfg = make_cfg(offManStealChancePct=50)
+```
+
 ## Lineup CSV Format
 Lineup files live in `data/lineups/` and are named `<TEAM>_vs_lhp.csv` or `<TEAM>_vs_rhp.csv`.
 Each file contains the columns:
@@ -30,6 +47,13 @@ Tests are located in the `tests/` directory and can be executed with:
 
 ```bash
 pytest
+```
+
+To run a single exhibition style scenario you can target an individual test,
+for example:
+
+```bash
+pytest tests/test_simulation.py::test_run_tracking_and_boxscore -q
 ```
 
 ### Default Admin Credentials

--- a/logic/defensive_manager.py
+++ b/logic/defensive_manager.py
@@ -2,24 +2,24 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Tuple
 
-from .pbini_loader import load_pbini
+from .playbalance_config import PlayBalanceConfig
 
 
 class DefensiveManager:
     """Handle defensive strategy decisions based on PB.INI configuration."""
 
-    def __init__(self, pbini: Dict[str, Dict[str, Any]], rng: random.Random | None = None) -> None:
-        self.config = pbini.get("PlayBalance", {})
+    def __init__(self, config: PlayBalanceConfig, rng: random.Random | None = None) -> None:
+        self.config = config
         self.rng = rng or random.Random()
 
     @classmethod
     def from_file(
         cls, path: str | Path, rng: random.Random | None = None
     ) -> "DefensiveManager":
-        pbini = load_pbini(path)
-        return cls(pbini, rng)
+        cfg = PlayBalanceConfig.from_file(path)
+        return cls(cfg, rng)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/logic/offensive_manager.py
+++ b/logic/offensive_manager.py
@@ -2,24 +2,23 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
-from typing import Any, Dict
 
-from .pbini_loader import load_pbini
+from .playbalance_config import PlayBalanceConfig
 
 
 class OffensiveManager:
     """Handle offensive strategy decisions based on PB.INI configuration."""
 
-    def __init__(self, pbini: Dict[str, Dict[str, Any]], rng: random.Random | None = None) -> None:
-        self.config = pbini.get("PlayBalance", {})
+    def __init__(self, config: PlayBalanceConfig, rng: random.Random | None = None) -> None:
+        self.config = config
         self.rng = rng or random.Random()
 
     @classmethod
     def from_file(
         cls, path: str | Path, rng: random.Random | None = None
     ) -> "OffensiveManager":
-        pbini = load_pbini(path)
-        return cls(pbini, rng)
+        cfg = PlayBalanceConfig.from_file(path)
+        return cls(cfg, rng)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/logic/playbalance_config.py
+++ b/logic/playbalance_config.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+from .pbini_loader import load_pbini
+
+# Default values for PlayBalance configuration entries used throughout the
+# simplified game logic.  Missing keys will fall back to these values when
+# accessed as attributes.  The majority of values default to ``0`` which keeps
+# related behaviour disabled unless explicitly enabled by a test case.  A small
+# number have different sensible defaults, e.g. ``swingSpeedBase`` which mirrors
+# the behaviour of the original game engine.
+_DEFAULTS: Dict[str, Any] = {
+    # Offensive manager ----------------------------------------------------
+    "offManStealChancePct": 0,
+    "stealChanceVerySlowThresh": 0,
+    "stealChanceVerySlowAdjust": 0,
+    "stealChanceSlowThresh": 0,
+    "stealChanceSlowAdjust": 0,
+    "stealChanceMedThresh": 0,
+    "stealChanceMedAdjust": 0,
+    "stealChanceFastThresh": 0,
+    "stealChanceFastAdjust": 0,
+    "stealChanceVeryFastAdjust": 0,
+    "stealChanceVeryLowHoldThresh": 0,
+    "stealChanceVeryLowHoldAdjust": 0,
+    "stealChanceLowHoldThresh": 0,
+    "stealChanceLowHoldAdjust": 0,
+    "stealChanceMedHoldThresh": 0,
+    "stealChanceMedHoldAdjust": 0,
+    "stealChanceHighHoldThresh": 0,
+    "stealChanceHighHoldAdjust": 0,
+    "stealChanceVeryHighHoldAdjust": 0,
+    "stealChancePitcherFaceAdjust": 0,
+    "stealChancePitcherBackAdjust": 0,
+    "stealChancePitcherWindupAdjust": 0,
+    "stealChancePitcherWildAdjust": 0,
+    "stealChanceOnFirst2OutHighCHThresh": 0,
+    "stealChanceOnFirst2OutHighCHAdjust": 0,
+    "stealChanceOnFirst2OutLowCHThresh": 0,
+    "stealChanceOnFirst2OutLowCHAdjust": 0,
+    "stealChanceOnFirst01OutHighCHThresh": 0,
+    "stealChanceOnFirst01OutHighCHAdjust": 0,
+    "stealChanceOnFirst01OutLowCHThresh": 0,
+    "stealChanceOnFirst01OutLowCHAdjust": 0,
+    "stealChanceOnSecond0OutAdjust": 0,
+    "stealChanceOnSecond1OutAdjust": 0,
+    "stealChanceOnSecond2OutAdjust": 0,
+    "stealChanceOnSecondHighCHThresh": 0,
+    "stealChanceOnSecondHighCHAdjust": 0,
+    "stealChanceWayBehindThresh": 0,
+    "stealChanceWayBehindAdjust": 0,
+    "hnrChanceBase": 0,
+    "hnrChance3MoreBehindAdjust": 0,
+    "hnrChance2BehindAdjust": 0,
+    "hnrChance1AheadAdjust": 0,
+    "hnrChance2MoreAheadAdjust": 0,
+    "hnrChanceOn12Adjust": 0,
+    "hnrChancePitcherWildAdjust": 0,
+    "hnrChance3BallsAdjust": 0,
+    "hnrChance2StrikesAdjust": 0,
+    "hnrChanceEvenCountAdjust": 0,
+    "hnrChance01CountAdjust": 0,
+    "hnrChanceSlowSPThresh": 0,
+    "hnrChanceSlowSPAdjust": 0,
+    "hnrChanceMedSPThresh": 0,
+    "hnrChanceMedSPAdjust": 0,
+    "hnrChanceFastSPThresh": 0,
+    "hnrChanceFastSPAdjust": 0,
+    "hnrChanceVeryFastSPAdjust": 0,
+    "hnrChanceLowCHThresh": 0,
+    "hnrChanceLowCHAdjust": 0,
+    "hnrChanceMedCHThresh": 0,
+    "hnrChanceMedCHAdjust": 0,
+    "hnrChanceHighCHThresh": 0,
+    "hnrChanceHighCHAdjust": 0,
+    "hnrChanceVeryHighCHAdjust": 0,
+    "hnrChanceLowPHThresh": 0,
+    "hnrChanceLowPHAdjust": 0,
+    "hnrChanceMedPHThresh": 0,
+    "hnrChanceMedPHAdjust": 0,
+    "hnrChanceHighPHThresh": 0,
+    "hnrChanceHighPHAdjust": 0,
+    "hnrChanceVeryHighPHAdjust": 0,
+    "offManHNRChancePct": 0,
+    "sacChanceMaxCH": 1000,
+    "sacChanceMaxPH": 1000,
+    "sacChanceBase": 0,
+    "sacChancePitcherAdjust": 0,
+    "sacChance1OutAdjust": 0,
+    "sacChanceCLAdjust": 0,
+    "sacChanceCL0OutOn12Adjust": 0,
+    "sacChanceCLLowCHThresh": 0,
+    "sacChanceCLLowPHThresh": 0,
+    "sacChanceCLLowCHPHAdjust": 0,
+    "sacChancePitcherLowCHThresh": 0,
+    "sacChancePitcherLowPHThresh": 0,
+    "sacChancePitcherLowCHPHAdjust": 0,
+    "offManSacChancePct": 0,
+    "squeezeChanceMaxCH": 1000,
+    "squeezeChanceMaxPH": 1000,
+    "offManSqueezeChancePct": 0,
+    "squeezeChanceLowCountAdjust": 0,
+    "squeezeChanceMedCountAdjust": 0,
+    "squeezeChanceThirdFastSPThresh": 0,
+    "squeezeChanceThirdFastAdjust": 0,
+    "swingSpeedBase": 50,
+    "swingSpeedPHPct": 0,
+    # Defensive manager ----------------------------------------------------
+    "chargeChanceBaseThird": 0,
+    "chargeChanceSacChanceAdjust": 0,
+    "defManChargeChancePct": 0,
+    "holdChanceBase": 0,
+    "holdChanceMinRunnerSpeed": 0,
+    "holdChanceAdjust": 0,
+    "pickoffChanceBase": 0,
+    "pickoffChanceStealChanceAdjust": 0,
+    "pickoffChanceLeadMult": 0,
+    "pickoffChancePitchesMult": 0,
+    "pitchOutChanceStealThresh": 0,
+    "pitchOutChanceHitRunThresh": 0,
+    "pitchOutChanceBase": 0,
+    "pitchOutChanceBall0Adjust": 0,
+    "pitchOutChanceBall1Adjust": 0,
+    "pitchOutChanceBall2Adjust": 0,
+    "pitchOutChanceBall3Adjust": 0,
+    "pitchOutChanceInn8Adjust": 0,
+    "pitchOutChanceInn9Adjust": 0,
+    "pitchOutChanceHomeAdjust": 0,
+    "pitchAroundChanceNoInn": 0,
+    "pitchAroundChanceBase": 0,
+    "pitchAroundChanceInn7Adjust": 0,
+    "pitchAroundChanceInn9Adjust": 0,
+    "defManPitchAroundToIBBPct": 0,
+    # Substitution manager -------------------------------------------------
+    "doubleSwitchPHAdjust": 0,
+    "pinchRunChance": 0,
+    "defSubChance": 0,
+    "doubleSwitchChance": 0,
+    "pitcherTiredThresh": 0,
+}
+
+
+@dataclass
+class PlayBalanceConfig:
+    """Container providing convenient access to ``PlayBalance`` entries.
+
+    The class behaves similarly to a mapping.  Values can be retrieved via the
+    :py:meth:`get` method or as attributes.  Missing keys return sensible
+    defaults to keep the simulation logic simple and predictable for the unit
+    tests.
+    """
+
+    values: Dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PlayBalanceConfig":
+        """Create an instance from a mapping produced by :func:`load_pbini`.
+
+        ``data`` may be either the full nested dictionary returned by
+        :func:`load_pbini` or already the ``PlayBalance`` sub-section.
+        """
+
+        if "PlayBalance" in data and isinstance(data["PlayBalance"], dict):
+            section = data["PlayBalance"]
+        else:
+            section = data
+        # Copy to avoid accidental sharing
+        return cls(dict(section))
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "PlayBalanceConfig":
+        """Load a PB.INI style file and return the ``PlayBalance`` section."""
+
+        pbini = load_pbini(path)
+        return cls.from_dict(pbini)
+
+    # ------------------------------------------------------------------
+    # Mapping style helpers
+    # ------------------------------------------------------------------
+    def get(self, key: str, default: Any = 0) -> Any:
+        """Return ``key`` from the configuration or ``default`` if missing."""
+
+        return self.values.get(key, default)
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple delegation
+        return self.values.get(item, _DEFAULTS.get(item, 0))
+
+    def __setattr__(self, key: str, value: Any) -> None:  # pragma: no cover - simple
+        if key == "values":
+            super().__setattr__(key, value)
+        else:
+            self.values[key] = value
+
+
+__all__ = ["PlayBalanceConfig"]

--- a/logic/simulation.py
+++ b/logic/simulation.py
@@ -9,6 +9,7 @@ from models.pitcher import Pitcher
 from logic.defensive_manager import DefensiveManager
 from logic.offensive_manager import OffensiveManager
 from logic.substitution_manager import SubstitutionManager
+from logic.playbalance_config import PlayBalanceConfig
 
 
 @dataclass
@@ -67,16 +68,16 @@ class GameSimulation:
         self,
         home: TeamState,
         away: TeamState,
-        pbini: Dict[str, Dict[str, int]],
+        config: PlayBalanceConfig,
         rng: Optional[random.Random] = None,
     ) -> None:
         self.home = home
         self.away = away
-        self.config = pbini.get("PlayBalance", {})
+        self.config = config
         self.rng = rng or random.Random()
-        self.defense = DefensiveManager(pbini, self.rng)
-        self.offense = OffensiveManager(pbini, self.rng)
-        self.subs = SubstitutionManager(pbini, self.rng)
+        self.defense = DefensiveManager(config, self.rng)
+        self.offense = OffensiveManager(config, self.rng)
+        self.subs = SubstitutionManager(config, self.rng)
         self.debug_log: List[str] = []
 
     # ------------------------------------------------------------------

--- a/logic/substitution_manager.py
+++ b/logic/substitution_manager.py
@@ -15,10 +15,11 @@ user can manually verify that substitutions occurred.
 """
 
 import random
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from models.player import Player
 from models.pitcher import Pitcher
+from .playbalance_config import PlayBalanceConfig
 
 if TYPE_CHECKING:  # pragma: no cover - used only for type checking
     from .simulation import BatterState, PitcherState, TeamState
@@ -29,15 +30,15 @@ class SubstitutionManager:
 
     Only small pieces of the real game's behaviour are implemented – enough
     for the unit tests to exercise the different code paths.  Chances for the
-    various substitutions are read from the ``PlayBalance`` section of the
-    parsed PB.INI configuration.  If a required key is missing the chance will
-    simply be zero which results in the substitution never triggering.
+    various substitutions are read from the ``PlayBalance`` configuration.  If
+    a required key is missing the chance will simply be zero which results in
+    the substitution never triggering.
     """
 
     def __init__(
-        self, pbini: Dict[str, Dict[str, int]], rng: Optional[random.Random] = None
+        self, config: PlayBalanceConfig, rng: Optional[random.Random] = None
     ) -> None:
-        self.config = pbini.get("PlayBalance", {})
+        self.config = config
         self.rng = rng or random.Random()
 
     # ------------------------------------------------------------------

--- a/tests/test_defensive_manager.py
+++ b/tests/test_defensive_manager.py
@@ -1,19 +1,18 @@
-from logic.defensive_manager import DefensiveManager
-
 import random
+
+from logic.defensive_manager import DefensiveManager
+from tests.util.pbini_factory import make_cfg
 
 
 class MockRandom(random.Random):
+    """Deterministic random generator using a predefined sequence."""
+
     def __init__(self, values):
         super().__init__()
         self.values = list(values)
 
     def random(self):  # type: ignore[override]
         return self.values.pop(0)
-
-
-def make_cfg(**entries):
-    return {"PlayBalance": entries}
 
 
 def test_charge_bunt_chance():

--- a/tests/test_offensive_manager.py
+++ b/tests/test_offensive_manager.py
@@ -1,11 +1,10 @@
 import random
-from pathlib import Path
 
 from logic.offensive_manager import OffensiveManager
-from logic.pbini_loader import load_pbini
 from logic.simulation import GameSimulation, TeamState, BatterState
 from models.player import Player
 from models.pitcher import Pitcher
+from tests.util.pbini_factory import make_cfg, load_config
 
 
 class MockRandom(random.Random):
@@ -17,12 +16,6 @@ class MockRandom(random.Random):
 
     def random(self):  # type: ignore[override]
         return self.values.pop(0)
-
-
-def make_cfg(**entries):
-    return {"PlayBalance": entries}
-
-
 def make_player(pid: str, ph: int = 50, sp: int = 50, ch: int = 50) -> Player:
     return Player(
         player_id=pid,
@@ -73,12 +66,6 @@ def make_pitcher(pid: str) -> Pitcher:
         fa=50,
         role="SP",
     )
-
-
-def load_config():
-    return load_pbini(Path("logic/PBINI.txt"))
-
-
 def test_calculate_steal_chance():
     cfg = make_cfg(
         offManStealChancePct=50,
@@ -116,7 +103,7 @@ def test_hit_and_run_chance_and_advance():
     assert om.maybe_hit_and_run(runner_sp=50, batter_ch=20, batter_ph=20, balls=3) is False
 
     full = load_config()
-    full["PlayBalance"].update({
+    full.values.update({
         "hnrChanceBase": 100,
         "offManHNRChancePct": 100,
         "pitchOutChanceBase": 0,
@@ -164,7 +151,7 @@ def test_sacrifice_bunt_chance_and_advance():
     ) is False
 
     full = load_config()
-    full["PlayBalance"].update({
+    full.values.update({
         "hnrChanceBase": 0,
         "offManHNRChancePct": 0,
         "sacChanceBase": 100,
@@ -197,7 +184,7 @@ def test_suicide_squeeze_chance_and_score():
     assert om.maybe_suicide_squeeze(batter_ch=50, batter_ph=50, balls=0, strikes=0, runner_on_third_sp=50) is False
 
     full = load_config()
-    full["PlayBalance"].update({
+    full.values.update({
         "hnrChanceBase": 0,
         "offManHNRChancePct": 0,
         "sacChanceBase": 0,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,8 +1,5 @@
-from pathlib import Path
-
 import random
 
-from logic.pbini_loader import load_pbini
 from logic.simulation import (
     BatterState,
     GameSimulation,
@@ -11,6 +8,7 @@ from logic.simulation import (
 )
 from models.player import Player
 from models.pitcher import Pitcher
+from tests.util.pbini_factory import load_config
 
 
 class MockRandom(random.Random):
@@ -76,12 +74,6 @@ def make_pitcher(
         fa=50,
         role=role,
     )
-
-
-def load_config():
-    return load_pbini(Path("logic/PBINI.txt"))
-
-
 def test_pinch_hitter_used():
     cfg = load_config()
     bench = make_player("bench", ph=80)
@@ -134,7 +126,7 @@ def test_steal_attempt_failure():
     runner_state = BatterState(runner)
     away.lineup_stats[runner.player_id] = runner_state
     away.bases[0] = runner_state
-    cfg["PlayBalance"].update({"pitchOutChanceBase": 0})
+    cfg.values.update({"pitchOutChanceBase": 0})
     # hnr success -> 0.0, steal failure -> 0.9, swing hit -> 0.0, post-hit steal attempt fails -> 1.0
     rng = MockRandom([0.0, 0.9, 0.0, 1.0])
     sim = GameSimulation(home, away, cfg, rng)

--- a/tests/test_substitution_manager.py
+++ b/tests/test_substitution_manager.py
@@ -1,12 +1,10 @@
-from pathlib import Path
-
 import random
 
-from logic.pbini_loader import load_pbini
 from logic.simulation import BatterState, TeamState
 from logic.substitution_manager import SubstitutionManager
 from models.player import Player
 from models.pitcher import Pitcher
+from tests.util.pbini_factory import load_config
 
 
 class MockRandom(random.Random):
@@ -72,15 +70,9 @@ def make_pitcher(pid: str, endurance: int = 100) -> Pitcher:
         fa=50,
         role="SP",
     )
-
-
-def load_config():
-    return load_pbini(Path("logic/PBINI.txt"))
-
-
 def test_pinch_hit():
     cfg = load_config()
-    cfg["PlayBalance"].update({"doubleSwitchPHAdjust": 100})
+    cfg.values.update({"doubleSwitchPHAdjust": 100})
     bench = make_player("bench", ph=80)
     starter = make_player("start", ph=10)
     team = TeamState(lineup=[starter], bench=[bench], pitchers=[make_pitcher("p")])
@@ -92,7 +84,7 @@ def test_pinch_hit():
 
 def test_pinch_run():
     cfg = load_config()
-    cfg["PlayBalance"].update({"pinchRunChance": 100})
+    cfg.values.update({"pinchRunChance": 100})
     runner = make_player("slow", sp=10)
     fast = make_player("fast", sp=90)
     team = TeamState(lineup=[runner], bench=[fast], pitchers=[make_pitcher("p")])
@@ -107,7 +99,7 @@ def test_pinch_run():
 
 def test_defensive_sub():
     cfg = load_config()
-    cfg["PlayBalance"].update({"defSubChance": 100})
+    cfg.values.update({"defSubChance": 100})
     weak = make_player("weak", gf=10)
     strong = make_player("strong", gf=90)
     team = TeamState(lineup=[weak], bench=[strong], pitchers=[make_pitcher("p")])
@@ -118,7 +110,7 @@ def test_defensive_sub():
 
 def test_double_switch():
     cfg = load_config()
-    cfg["PlayBalance"].update({"doubleSwitchChance": 100, "doubleSwitchPHAdjust": 100})
+    cfg.values.update({"doubleSwitchChance": 100, "doubleSwitchPHAdjust": 100})
     bench_hitter = make_player("bench", ph=80)
     starter = make_player("start", ph=10)
     offense = TeamState(lineup=[starter], bench=[bench_hitter], pitchers=[make_pitcher("op")])

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,1 @@
+# Utility package for test helpers.

--- a/tests/util/pbini_factory.py
+++ b/tests/util/pbini_factory.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from logic.playbalance_config import PlayBalanceConfig
+from logic.pbini_loader import load_pbini
+
+
+def make_cfg(**entries: int) -> PlayBalanceConfig:
+    """Return a :class:`PlayBalanceConfig` with ``entries`` overridden.
+
+    Only the provided entries are included; unspecified keys fall back to the
+    defaults provided by :class:`PlayBalanceConfig` when accessed.
+    """
+
+    return PlayBalanceConfig.from_dict({"PlayBalance": entries})
+
+
+def load_config() -> PlayBalanceConfig:
+    """Load the full test configuration from ``logic/PBINI.txt``."""
+
+    pbini = load_pbini(Path("logic/PBINI.txt"))
+    return PlayBalanceConfig.from_dict(pbini)

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -16,7 +16,7 @@ from utils.player_loader import load_players_from_csv
 from utils.roster_loader import load_roster
 from logic.simulation import GameSimulation, TeamState, generate_boxscore
 from models.pitcher import Pitcher
-from logic.pbini_loader import load_pbini
+from logic.playbalance_config import PlayBalanceConfig
 
 
 class ExhibitionGameDialog(QDialog):
@@ -104,7 +104,9 @@ class ExhibitionGameDialog(QDialog):
         try:
             home_state = self._build_state(home_id)
             away_state = self._build_state(away_id)
-            cfg = load_pbini(os.path.join(os.path.dirname(__file__), "..", "logic", "PBINI.txt"))
+            cfg = PlayBalanceConfig.from_file(
+                os.path.join(os.path.dirname(__file__), "..", "logic", "PBINI.txt")
+            )
             sim = GameSimulation(home_state, away_state, cfg)
             sim.simulate_game()
             box = generate_boxscore(home_state, away_state)


### PR DESCRIPTION
## Summary
- introduce `PlayBalanceConfig` dataclass to parse and expose PB.INI `PlayBalance` values with safe defaults
- refactor managers and game simulation to depend on the new dataclass
- add `pbini_factory` test helper and document configuration usage with example test commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aac7ed558832e8975303bcc7bdeb2