### PR TITLE
Add player avatar generation to admin console

### DIFF
--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -73,6 +73,10 @@ class AdminDashboard(QWidget):
         self.generate_logos_button.clicked.connect(self.generate_team_logos)
         button_layout.addWidget(self.generate_logos_button, alignment=Qt.AlignmentFlag.AlignHCenter)
 
+        self.generate_avatars_button = QPushButton("Generate Player Avatars")
+        self.generate_avatars_button.clicked.connect(self.generate_player_avatars)
+        button_layout.addWidget(self.generate_avatars_button, alignment=Qt.AlignmentFlag.AlignHCenter)
+
         self.exhibition_button = QPushButton("Simulate Exhibition Game")
         self.exhibition_button.clicked.connect(self.open_exhibition_dialog)
         button_layout.addWidget(self.exhibition_button, alignment=Qt.AlignmentFlag.AlignHCenter)
@@ -182,6 +186,18 @@ class AdminDashboard(QWidget):
             )
         except Exception as e:
             QMessageBox.warning(self, "Error", f"Failed to generate logos: {e}")
+
+    def generate_player_avatars(self):
+        try:
+            from utils.avatar_generator import generate_player_avatars as gen_avatars
+            out_dir = gen_avatars()
+            QMessageBox.information(
+                self,
+                "Avatars Generated",
+                f"Player avatars created in: {out_dir}",
+            )
+        except Exception as e:
+            QMessageBox.warning(self, "Error", f"Failed to generate avatars: {e}")
 
     def open_exhibition_dialog(self):
         dialog = ExhibitionGameDialog(self)

--- a/utils/avatar_generator.py
+++ b/utils/avatar_generator.py
@@ -1,0 +1,70 @@
+"""Utilities for generating player avatar images.
+
+Creates simple illustrated headshots for each player using the
+:mod:`images.avatars` module. Avatars are written to ``images/avatars``
+relative to the repository root and named after the player's ID.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from PIL import Image
+
+from images.avatars import generate_player_headshot
+from utils.player_loader import load_players_from_csv
+from utils.team_loader import load_teams
+from utils.roster_loader import load_roster
+
+
+def generate_player_avatars(out_dir: str | None = None, size: int = 512) -> str:
+    """Generate avatar images for all players and return the output directory.
+
+    Parameters
+    ----------
+    out_dir:
+        Optional output directory. Defaults to ``images/avatars`` relative to
+        the project root.
+    size:
+        Pixel size for the generated square avatars.
+    """
+
+    players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
+    teams = load_teams("data/teams.csv")
+
+    # Map each player ID to their team ID via roster files
+    player_team: Dict[str, str] = {}
+    for t in teams:
+        try:
+            roster = load_roster(t.team_id)
+        except FileNotFoundError:
+            continue
+        for pid in roster.act + roster.aaa + roster.low:
+            player_team[pid] = t.team_id
+
+    if out_dir is None:
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        out_dir = os.path.join(base_dir, "images", "avatars")
+    os.makedirs(out_dir, exist_ok=True)
+
+    team_map = {t.team_id: t for t in teams}
+    for pid, player in players.items():
+        team_id = player_team.get(pid)
+        if not team_id:
+            continue
+        team = team_map.get(team_id)
+        if not team:
+            continue
+        name = f"{player.first_name} {player.last_name}"
+        img = generate_player_headshot(
+            player_name=name,
+            team_primary_hex=team.primary_color,
+            team_secondary_hex=team.secondary_color,
+            size=size,
+        )
+        img.save(os.path.join(out_dir, f"{pid}.png"))
+        # Smaller version for UI thumbnails
+        thumb = img.resize((150, 150), resample=Image.LANCZOS)
+        thumb.save(os.path.join(out_dir, f"{pid}_150.png"))
+
+    return out_dir


### PR DESCRIPTION
## Summary
- add button in admin dashboard to create player avatars
- implement utility to generate avatars for all players based on team colors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab0ab7ff4832ea7915fb0b3e448be