### PR TITLE
Add player profile dialog and link from player lists

### DIFF
--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -13,6 +13,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from ui.player_profile_dialog import PlayerProfileDialog
+
 from models.base_player import BasePlayer
 from models.roster import Roster
 from utils.pitcher_role import get_role
@@ -61,6 +63,7 @@ class PitchersWindow(QDialog):
             lw = QListWidget()
             for player in players:
                 lw.addItem(self._make_pitcher_item(player))
+            lw.itemDoubleClicked.connect(self._open_player_profile)
             label = "Starting Pitchers (SP)" if role == "SP" else "Relief Pitchers (RP)"
             tab_widget.addTab(lw, label)
 
@@ -88,4 +91,14 @@ class PitchersWindow(QDialog):
             )
         except Exception:
             return "?"
+
+    # ------------------------------------------------------------------
+    # Player profile dialog
+    def _open_player_profile(self, item: QListWidgetItem):
+        """Open the player profile dialog for the selected pitcher."""
+        pid = item.data(Qt.ItemDataRole.UserRole)
+        player = self.players.get(pid)
+        if not player:
+            return
+        PlayerProfileDialog(player, self).exec()
 

--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -1,0 +1,120 @@
+"""Dialog for displaying a player's profile with avatar, info, ratings and stats."""
+
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from typing import Dict, Any
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QGridLayout,
+    QGroupBox,
+)
+
+from models.base_player import BasePlayer
+
+
+class PlayerProfileDialog(QDialog):
+    """Display basic information, current ratings and stats for a player."""
+
+    def __init__(self, player: BasePlayer, parent=None):
+        super().__init__(parent)
+        self.player = player
+        self.setWindowTitle(f"{player.first_name} {player.last_name}")
+
+        layout = QVBoxLayout()
+        layout.addLayout(self._build_header())
+
+        ratings = self._collect_ratings()
+        if ratings:
+            layout.addWidget(self._build_grid("Ratings", ratings))
+
+        for attr, label in [("season_stats", "Season Stats"), ("career_stats", "Career Stats")]:
+            if hasattr(player, attr):
+                stats = self._stats_to_dict(getattr(player, attr))
+                if stats:
+                    layout.addWidget(self._build_grid(label, stats))
+
+        self.setLayout(layout)
+
+    # ------------------------------------------------------------------
+    def _build_header(self) -> QHBoxLayout:
+        """Create the top section with avatar and basic info."""
+        layout = QHBoxLayout()
+
+        avatar_label = QLabel()
+        pix = QPixmap(f"images/avatars/{self.player.player_id}.png")
+        if pix.isNull():
+            pix = QPixmap("images/avatars/default.png")
+        if not pix.isNull():
+            pix = pix.scaled(128, 128, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+        avatar_label.setPixmap(pix)
+        layout.addWidget(avatar_label)
+
+        info_layout = QVBoxLayout()
+        info_layout.addWidget(QLabel(f"Name: {self.player.first_name} {self.player.last_name}"))
+        age = self._calculate_age(self.player.birthdate)
+        info_layout.addWidget(QLabel(f"Age: {age}"))
+        info_layout.addWidget(QLabel(f"Height: {getattr(self.player, 'height', '?')}") )
+        info_layout.addWidget(QLabel(f"Weight: {getattr(self.player, 'weight', '?')}") )
+        info_layout.addWidget(QLabel(f"Bats: {getattr(self.player, 'bats', '?')}") )
+        positions = ", ".join([self.player.primary_position, *getattr(self.player, 'other_positions', [])])
+        info_layout.addWidget(QLabel(f"Positions: {positions}"))
+        layout.addLayout(info_layout)
+
+        return layout
+
+    def _collect_ratings(self) -> Dict[str, Any]:
+        """Gather non-potential numeric ratings for the player."""
+        excluded = {
+            "player_id",
+            "first_name",
+            "last_name",
+            "birthdate",
+            "height",
+            "weight",
+            "bats",
+            "primary_position",
+            "other_positions",
+            "gf",
+            "injured",
+            "injury_description",
+            "return_date",
+        }
+        ratings = {}
+        for key, val in vars(self.player).items():
+            if key in excluded or key.startswith("pot_"):
+                continue
+            if isinstance(val, (int, float)):
+                ratings[key] = val
+        return ratings
+
+    def _stats_to_dict(self, stats: Any) -> Dict[str, Any]:
+        if isinstance(stats, dict):
+            return stats
+        if is_dataclass(stats):
+            return asdict(stats)
+        return {}
+
+    def _build_grid(self, title: str, data: Dict[str, Any]) -> QGroupBox:
+        group = QGroupBox(title)
+        grid = QGridLayout()
+        for row, (key, val) in enumerate(data.items()):
+            grid.addWidget(QLabel(str(key).replace("_", " ").title()), row, 0)
+            grid.addWidget(QLabel(str(val)), row, 1)
+        group.setLayout(grid)
+        return group
+
+    def _calculate_age(self, birthdate_str: str):
+        try:
+            birthdate = datetime.strptime(birthdate_str, "%Y-%m-%d").date()
+            today = datetime.today().date()
+            return today.year - birthdate.year - (
+                (today.month, today.day) < (birthdate.month, birthdate.day)
+            )
+        except Exception:
+            return "?"

--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -13,6 +13,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from ui.player_profile_dialog import PlayerProfileDialog
+
 from models.base_player import BasePlayer
 from models.roster import Roster
 from utils.pitcher_role import get_role
@@ -63,6 +65,7 @@ class PositionPlayersDialog(QDialog):
             lw = QListWidget()
             for player in players:
                 lw.addItem(self._make_player_item(player))
+            lw.itemDoubleClicked.connect(self._open_player_profile)
             tab_widget.addTab(lw, position)
 
         layout.addWidget(tab_widget)
@@ -94,4 +97,14 @@ class PositionPlayersDialog(QDialog):
             )
         except Exception:
             return "?"
+
+    # ------------------------------------------------------------------
+    # Player profile dialog
+    def _open_player_profile(self, item: QListWidgetItem):
+        """Open the player profile dialog for the selected item."""
+        pid = item.data(Qt.ItemDataRole.UserRole)
+        player = self.players.get(pid)
+        if not player:
+            return
+        PlayerProfileDialog(player, self).exec()
 


### PR DESCRIPTION
## Summary
- Add PlayerProfileDialog to show avatar, bio, ratings, and optional stats for a player
- Double-clicking players in PositionPlayersDialog and PitchersWindow now opens the profile dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab514ed3c832ebe4ebd55eaa580d9