### PR TITLE
Add seeded auto logo generation with deterministic output

### DIFF
--- a/tests/test_logo_determinism.py
+++ b/tests/test_logo_determinism.py
@@ -1,0 +1,16 @@
+import hashlib
+import pytest
+
+pytest.importorskip("PIL")
+
+from images.auto_logo import TeamSpec, generate_logo
+
+
+def test_logo_determinism_same_mascot():
+    spec1 = TeamSpec(location="Test City", mascot="Cobras", template="auto")
+    spec2 = TeamSpec(location="Test City", mascot="Cobras", template="auto")
+    img1 = generate_logo(spec1, size=64)
+    img2 = generate_logo(spec2, size=64)
+    h1 = hashlib.sha256(img1.tobytes()).hexdigest()
+    h2 = hashlib.sha256(img2.tobytes()).hexdigest()
+    assert h1 == h2

--- a/utils/logo_generator.py
+++ b/utils/logo_generator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from typing import Callable, List, Optional
 
-from images.auto_logo import TeamSpec, batch_generate
+from images.auto_logo import TeamSpec, batch_generate, _seed_from_name
 from utils.team_loader import load_teams
 
 
@@ -42,6 +42,8 @@ def generate_team_logos(
                 primary=t.primary_color,
                 secondary=t.secondary_color,
                 abbrev=t.team_id,
+                template="auto",
+                seed=_seed_from_name(t.name, t.city),
             )
         )
 


### PR DESCRIPTION
## Summary
- allow TeamSpec to carry an optional seed and drive all randomness through a seeded generator
- support auto template selection and seeded color palettes in logo generation
- populate TeamSpec with seed/template in logo generator utility and add determinism test

## Testing
- `pytest -q`
- `pip install pillow` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bad3159b4832eaec7d8aeb0ef487f