### PR TITLE
Add SDXL avatar generator and UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ order,player_id,position
 `player_id` uses the internal IDs such as `P1000`.
 
 ## Development
-Install the dependencies (see `requirements.txt` if present) then run:
+Install the dependencies (see `requirements.txt`) then run:
 
 ```bash
 python main.py
 ```
+
+The `requirements.txt` file includes optional machine learning libraries used for
+advanced SDXL avatar generation (`diffusers`, `transformers`, `torch`,
+`opencv-python`, `diskcache`). If you only need the basic features you may omit
+those packages.
 
 ### Running tests
 Tests are located in the `tests/` directory and can be executed with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+PyQt6
+Pillow
+diffusers
+transformers
+torch
+opencv-python
+diskcache

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -212,6 +212,30 @@ class AdminDashboard(QWidget):
         players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
         teams = load_teams("data/teams.csv")
 
+        # Ask the admin which generation method to use
+        method, ok = QInputDialog.getItem(
+            self,
+            "Avatar Generation",
+            "Select generation method:",
+            ["Basic", "SDXL"],
+            0,
+            False,
+        )
+        if not ok:
+            return
+
+        controlnet = None
+        ip_adapter = None
+        if method == "SDXL":
+            controlnet, _ = QInputDialog.getText(
+                self, "ControlNet Path", "Optional ControlNet model path:"
+            )
+            ip_adapter, _ = QInputDialog.getText(
+                self, "IP-Adapter Path", "Optional IP-Adapter model path:"
+            )
+            controlnet = controlnet or None
+            ip_adapter = ip_adapter or None
+
         player_ids = set()
         for t in teams:
             try:
@@ -239,7 +263,15 @@ class AdminDashboard(QWidget):
 
         try:
             from utils.avatar_generator import generate_player_avatars as gen_avatars
-            out_dir = gen_avatars(progress_callback=cb)
+
+            out_dir = gen_avatars(
+                progress_callback=cb,
+                use_sdxl=method == "SDXL",
+                players=players,
+                teams=teams,
+                controlnet_path=controlnet,
+                ip_adapter_path=ip_adapter,
+            )
             QMessageBox.information(
                 self,
                 "Avatars Generated",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility package for UBL."""
+
+from .ubl_avatar_generator import generate_player_avatars_sdxl  # noqa: F401
+
+__all__ = ["generate_player_avatars_sdxl"]

--- a/utils/ubl_avatar_generator.py
+++ b/utils/ubl_avatar_generator.py
@@ -1,0 +1,153 @@
+"""SDXL-based player avatar generation utilities.
+
+This module provides a :func:`generate_player_avatars_sdxl` function which
+leverages the Stable Diffusion XL pipeline to create more realistic player
+avatars.  Heavy ML dependencies are imported lazily so that the rest of the
+application can be used without them installed.
+"""
+from __future__ import annotations
+
+import os
+from typing import Callable, Dict, Optional
+
+from utils.player_loader import load_players_from_csv
+from utils.team_loader import load_teams
+from utils.roster_loader import load_roster
+
+
+def generate_player_avatars_sdxl(
+    out_dir: str | None = None,
+    size: int = 512,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+    players: Dict[str, object] | None = None,
+    teams: list | None = None,
+    controlnet_path: str | None = None,
+    ip_adapter_path: str | None = None,
+) -> str:
+    """Generate player avatars using Stable Diffusion XL and return the output directory.
+
+    Parameters
+    ----------
+    out_dir:
+        Optional output directory. Defaults to ``images/avatars`` relative to the
+        project root.
+    size:
+        Pixel size for the generated square avatars.
+    progress_callback:
+        Optional callback receiving ``(completed, total)`` after each avatar is
+        saved. Useful for updating progress displays.
+    players, teams:
+        Optional pre-loaded player dictionary and team list. If omitted they are
+        loaded from disk internally.
+    controlnet_path, ip_adapter_path:
+        Optional paths to ControlNet and IP-Adapter models to further customise
+        generation.
+    """
+
+    # Heavy imports are delayed to keep normal operation lightweight
+    try:
+        from PIL import Image
+        from diskcache import Cache
+        import torch
+        from diffusers import StableDiffusionXLPipeline
+    except Exception as exc:  # pragma: no cover - Only executed when deps missing
+        raise RuntimeError(
+            "SDXL avatar generation requires diffusers, transformers, torch, "
+            "Pillow and diskcache to be installed"
+        ) from exc
+
+    if players is None:
+        players = {p.player_id: p for p in load_players_from_csv("data/players.csv")}
+    if teams is None:
+        teams = load_teams("data/teams.csv")
+
+    # Map each player ID to their team ID via roster files
+    player_team: Dict[str, str] = {}
+    for t in teams:
+        try:
+            roster = load_roster(t.team_id)
+        except FileNotFoundError:
+            continue
+        for pid in roster.act + roster.aaa + roster.low:
+            player_team[pid] = t.team_id
+
+    total = sum(1 for pid in players if pid in player_team)
+    completed = 0
+
+    if out_dir is None:
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        out_dir = os.path.join(base_dir, "images", "avatars")
+    os.makedirs(out_dir, exist_ok=True)
+
+    cache = Cache(os.path.join(out_dir, ".cache"))
+
+    # Initialise the SDXL pipeline
+    model_id = "stabilityai/stable-diffusion-xl-base-1.0"
+    pipe = StableDiffusionXLPipeline.from_pretrained(
+        model_id, torch_dtype=torch.float16
+    )
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    pipe.to(device)
+
+    if controlnet_path:
+        try:
+            from diffusers import ControlNetModel
+
+            controlnet = ControlNetModel.from_pretrained(
+                controlnet_path, torch_dtype=torch.float16
+            )
+            pipe.controlnet = controlnet
+        except Exception:
+            pass  # Best-effort loading only
+
+    if ip_adapter_path:
+        try:  # diffusers provides a helper for IP-Adapter models
+            pipe.load_ip_adapter(ip_adapter_path)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+    team_map = {t.team_id: t for t in teams}
+
+    for pid, player in players.items():
+        team_id = player_team.get(pid)
+        if not team_id:
+            continue
+        team = team_map.get(team_id)
+        if not team:
+            continue
+
+        cache_key = f"{pid}-{team.primary_color}-{team.secondary_color}"
+        out_path = os.path.join(out_dir, f"{pid}.png")
+        thumb_path = os.path.join(out_dir, f"{pid}_150.png")
+
+        # Skip generation if we already have an image for this player
+        cached_file = cache.get(cache_key)
+        if cached_file and os.path.exists(cached_file):
+            if not os.path.exists(out_path):
+                Image.open(cached_file).save(out_path)
+            if not os.path.exists(thumb_path):
+                img = Image.open(cached_file).resize((150, 150), resample=Image.LANCZOS)
+                img.save(thumb_path)
+            completed += 1
+            if progress_callback:
+                progress_callback(completed, total)
+            continue
+
+        prompt = (
+            f"portrait photo of {player.first_name} {player.last_name} as a baseball "
+            f"player, {team.name} colours"
+        )
+        image = pipe(prompt).images[0]
+        image = image.resize((size, size))
+        image.save(out_path)
+        thumb = image.resize((150, 150), resample=Image.LANCZOS)
+        thumb.save(thumb_path)
+
+        cache.set(cache_key, out_path)
+
+        completed += 1
+        if progress_callback:
+            progress_callback(completed, total)
+
+    cache.close()
+    return out_dir


### PR DESCRIPTION
## Summary
- add SDXL-based avatar generator with disk caching and optional ControlNet/IP-Adapter
- allow avatar generator to switch to SDXL via flag and expose CLI
- update admin dashboard to choose Basic vs SDXL avatar creation
- document ML dependencies and add requirements file

## Testing
- `python3 -m py_compile ui/admin_dashboard.py utils/avatar_generator.py utils/ubl_avatar_generator.py utils/__init__.py`
- `pytest` *(fails: command not found)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_689bb068cef0832e8214d07b7585071a