### PR TITLE
Add standings dialog with menu hook

### DIFF
--- a/tests/test_make_player_item.py
+++ b/tests/test_make_player_item.py
@@ -27,7 +27,7 @@ qtwidgets = types.ModuleType("PyQt6.QtWidgets")
 widget_names = [
     'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
     'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QDialog','QFormLayout',
-    'QSpinBox','QGridLayout','QScrollArea','QLineEdit'
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem'
 ]
 for name in widget_names:
     setattr(qtwidgets, name, Dummy)

--- a/tests/test_standings_window.py
+++ b/tests/test_standings_window.py
@@ -1,0 +1,156 @@
+import sys, types, os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# ---- Stub PyQt6 modules ----
+class DummySignal:
+    def __init__(self):
+        self._slot = None
+    def connect(self, slot):
+        self._slot = slot
+    def emit(self):
+        if self._slot:
+            self._slot()
+
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        self.clicked = DummySignal()
+        self.triggered = DummySignal()
+    def __getattr__(self, name):
+        return Dummy()
+    def addItem(self, *args, **kwargs):
+        pass
+    def clear(self, *args, **kwargs):
+        pass
+    def setLayout(self, *args, **kwargs):
+        pass
+    def connect(self, *args, **kwargs):
+        pass
+    def setFont(self, *args, **kwargs):
+        pass
+    def exec(self, *args, **kwargs):
+        pass
+    def setPlainText(self, *args, **kwargs):
+        pass
+    def setReadOnly(self, *args, **kwargs):
+        pass
+    def setStyleSheet(self, *args, **kwargs):
+        pass
+    def setMinimumHeight(self, *args, **kwargs):
+        pass
+    def setWindowTitle(self, *args, **kwargs):
+        pass
+    def setGeometry(self, *args, **kwargs):
+        pass
+    def setContentsMargins(self, *args, **kwargs):
+        pass
+    def addTab(self, *args, **kwargs):
+        pass
+    def addStretch(self, *args, **kwargs):
+        pass
+    def setMenuBar(self, *args, **kwargs):
+        pass
+    def addWidget(self, *args, **kwargs):
+        pass
+    def addItems(self, *args, **kwargs):
+        pass
+    def currentItem(self):
+        return None
+    def setText(self, *args, **kwargs):
+        pass
+    def warning(self, *args, **kwargs):
+        return 0
+    def information(self, *args, **kwargs):
+        return 0
+    def critical(self, *args, **kwargs):
+        return 0
+    def question(self, *args, **kwargs):
+        return 0
+
+class QAction:
+    def __init__(self, *args, **kwargs):
+        self.triggered = DummySignal()
+    def trigger(self):
+        self.triggered.emit()
+
+class QMenu(Dummy):
+    def addAction(self, *args, **kwargs):
+        return QAction()
+
+class QMenuBar(Dummy):
+    def addMenu(self, *args, **kwargs):
+        return QMenu()
+
+qtwidgets = types.ModuleType("PyQt6.QtWidgets")
+widget_names = [
+    'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
+    'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QDialog','QFormLayout',
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit','QTableWidget','QTableWidgetItem'
+]
+for name in widget_names:
+    setattr(qtwidgets, name, Dummy)
+qtwidgets.QMenuBar = QMenuBar
+qtwidgets.QMenu = QMenu
+qtwidgets.QAction = QAction
+
+class QListWidgetItem:
+    def __init__(self, text):
+        self._text = text
+        self._data = {}
+    def setData(self, role, value):
+        self._data[role] = value
+    def data(self, role):
+        return self._data.get(role)
+    def text(self):
+        return self._text
+qtwidgets.QListWidgetItem = QListWidgetItem
+
+qtcore = types.ModuleType("PyQt6.QtCore")
+class Qt:
+    pass
+qtcore.Qt = Qt
+class QPropertyAnimation:
+    pass
+qtcore.QPropertyAnimation = QPropertyAnimation
+sys.modules['PyQt6'] = types.ModuleType('PyQt6')
+sys.modules['PyQt6.QtWidgets'] = qtwidgets
+sys.modules['PyQt6.QtCore'] = qtcore
+
+qtgui = types.ModuleType("PyQt6.QtGui")
+class QFont:
+    def __init__(self, *args, **kwargs):
+        pass
+    def setBold(self, *args, **kwargs):
+        pass
+    def setPointSize(self, *args, **kwargs):
+        pass
+qtgui.QFont = QFont
+qtgui.QPixmap = Dummy
+sys.modules['PyQt6.QtGui'] = qtgui
+
+# ---- Imports after stubbing ----
+import ui.owner_dashboard as owner_dashboard
+
+
+def test_standings_action_opens_dialog(monkeypatch):
+    opened = {}
+
+    class DummyStandings:
+        def __init__(self, *a, **k):
+            pass
+        def exec(self):
+            opened["shown"] = True
+
+    monkeypatch.setattr(owner_dashboard, "StandingsWindow", DummyStandings)
+
+    def fake_init(self, team_id):
+        self.team_id = team_id
+        self.standings_action = QAction()
+        self.standings_action.triggered.connect(self.open_standings_window)
+
+    monkeypatch.setattr(owner_dashboard.OwnerDashboard, "__init__", fake_init)
+
+    dashboard = owner_dashboard.OwnerDashboard("DRO")
+    dashboard.standings_action.trigger()
+
+    assert opened.get("shown")

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -33,6 +33,7 @@ from ui.position_players_dialog import PositionPlayersDialog
 from ui.pitchers_window import PitchersWindow
 from ui.transactions_window import TransactionsWindow
 from ui.team_settings_dialog import TeamSettingsDialog
+from ui.standings_window import StandingsWindow
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
@@ -104,8 +105,9 @@ class OwnerDashboard(QWidget):
         trans_action.triggered.connect(self.open_transactions_page)
         settings_action.triggered.connect(self.open_team_settings)
         league_menu = menubar.addMenu("League")
-        league_menu.addAction("Standings")
+        self.standings_action = league_menu.addAction("Standings")
         league_menu.addAction("Schedule")
+        self.standings_action.triggered.connect(self.open_standings_window)
         main.setMenuBar(menubar)
 
         base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -267,6 +269,10 @@ class OwnerDashboard(QWidget):
 
     def open_transactions_page(self):
         TransactionsWindow().exec()
+
+    def open_standings_window(self):
+        """Open the league standings dialog."""
+        StandingsWindow(self).exec()
 
     def open_team_settings(self):
         if not self.team:

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -1,0 +1,33 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+
+class StandingsWindow(QDialog):
+    """Simple dialog displaying dummy league standings."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Standings")
+
+        layout = QVBoxLayout(self)
+
+        table = QTableWidget()
+        data = [
+            ("Team A", 10, 5),
+            ("Team B", 8, 7),
+            ("Team C", 7, 8),
+            ("Team D", 5, 10),
+        ]
+        table.setColumnCount(3)
+        table.setRowCount(len(data))
+        table.setHorizontalHeaderLabels(["Team", "Wins", "Losses"])
+        for row, (team, wins, losses) in enumerate(data):
+            table.setItem(row, 0, QTableWidgetItem(team))
+            table.setItem(row, 1, QTableWidgetItem(str(wins)))
+            table.setItem(row, 2, QTableWidgetItem(str(losses)))
+        table.resizeColumnsToContents()
+        layout.addWidget(table)


### PR DESCRIPTION
## Summary
- add `StandingsWindow` dialog showing placeholder league standings
- hook owner dashboard's League->Standings action to launch the dialog
- test that the standings action opens the dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf95efc5c832e904eb33948861991