### PR TITLE
Add schedule window and connect in owner dashboard

### DIFF
--- a/tests/test_schedule_window.py
+++ b/tests/test_schedule_window.py
@@ -1,0 +1,194 @@
+import sys, types, os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# ---- Stub PyQt6 modules ----
+class DummySignal:
+    def __init__(self):
+        self._slot = None
+    def connect(self, slot):
+        self._slot = slot
+    def emit(self):
+        if self._slot:
+            self._slot()
+
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        self.clicked = DummySignal()
+        self.triggered = DummySignal()
+    def __getattr__(self, name):
+        return Dummy()
+    def addItem(self, *args, **kwargs):
+        pass
+    def clear(self, *args, **kwargs):
+        pass
+    def setLayout(self, *args, **kwargs):
+        pass
+    def connect(self, *args, **kwargs):
+        pass
+    def setFont(self, *args, **kwargs):
+        pass
+    def exec(self, *args, **kwargs):
+        pass
+    def setPlainText(self, *args, **kwargs):
+        pass
+    def setReadOnly(self, *args, **kwargs):
+        pass
+    def setStyleSheet(self, *args, **kwargs):
+        pass
+    def setMinimumHeight(self, *args, **kwargs):
+        pass
+    def setWindowTitle(self, *args, **kwargs):
+        pass
+    def setGeometry(self, *args, **kwargs):
+        pass
+    def setContentsMargins(self, *args, **kwargs):
+        pass
+    def addTab(self, *args, **kwargs):
+        pass
+    def addStretch(self, *args, **kwargs):
+        pass
+    def setMenuBar(self, *args, **kwargs):
+        pass
+    def addWidget(self, *args, **kwargs):
+        pass
+    def addItems(self, *args, **kwargs):
+        pass
+    def currentItem(self):
+        return None
+    def setText(self, *args, **kwargs):
+        pass
+    def warning(self, *args, **kwargs):
+        return 0
+    def information(self, *args, **kwargs):
+        return 0
+    def critical(self, *args, **kwargs):
+        return 0
+    def question(self, *args, **kwargs):
+        return 0
+
+class QAction:
+    def __init__(self, *args, **kwargs):
+        self.triggered = DummySignal()
+    def trigger(self):
+        self.triggered.emit()
+
+class QMenu(Dummy):
+    def addAction(self, *args, **kwargs):
+        return QAction()
+
+class QMenuBar(Dummy):
+    def addMenu(self, *args, **kwargs):
+        return QMenu()
+
+# Table-specific stubs
+class QTableWidget(Dummy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._items = {}
+        self._rows = 0
+        self._cols = 0
+    def setColumnCount(self, n):
+        self._cols = n
+    def setRowCount(self, n):
+        self._rows = n
+    def setHorizontalHeaderLabels(self, labels):
+        self._headers = labels
+    def setItem(self, row, col, item):
+        self._items[(row, col)] = item
+    def item(self, row, col):
+        return self._items.get((row, col))
+    def resizeColumnsToContents(self):
+        pass
+
+class QTableWidgetItem:
+    def __init__(self, text):
+        self._text = text
+    def text(self):
+        return self._text
+
+qtwidgets = types.ModuleType("PyQt6.QtWidgets")
+widget_names = [
+    'QWidget','QLabel','QVBoxLayout','QTabWidget','QListWidget','QTextEdit','QPushButton',
+    'QHBoxLayout','QComboBox','QMessageBox','QGroupBox','QMenuBar','QDialog','QFormLayout',
+    'QSpinBox','QGridLayout','QScrollArea','QLineEdit'
+]
+for name in widget_names:
+    setattr(qtwidgets, name, Dummy)
+qtwidgets.QMenuBar = QMenuBar
+qtwidgets.QMenu = QMenu
+qtwidgets.QAction = QAction
+qtwidgets.QTableWidget = QTableWidget
+qtwidgets.QTableWidgetItem = QTableWidgetItem
+
+class QListWidgetItem:
+    def __init__(self, text):
+        self._text = text
+        self._data = {}
+    def setData(self, role, value):
+        self._data[role] = value
+    def data(self, role):
+        return self._data.get(role)
+    def text(self):
+        return self._text
+qtwidgets.QListWidgetItem = QListWidgetItem
+
+qtcore = types.ModuleType("PyQt6.QtCore")
+class Qt:
+    class ItemDataRole:
+        UserRole = 0
+qtcore.Qt = Qt
+class QPropertyAnimation:
+    pass
+qtcore.QPropertyAnimation = QPropertyAnimation
+sys.modules['PyQt6'] = types.ModuleType('PyQt6')
+sys.modules['PyQt6.QtWidgets'] = qtwidgets
+sys.modules['PyQt6.QtCore'] = qtcore
+
+qtgui = types.ModuleType("PyQt6.QtGui")
+class QFont:
+    def __init__(self, *args, **kwargs):
+        pass
+    def setBold(self, *args, **kwargs):
+        pass
+    def setPointSize(self, *args, **kwargs):
+        pass
+qtgui.QFont = QFont
+qtgui.QPixmap = Dummy
+sys.modules['PyQt6.QtGui'] = qtgui
+
+# ---- Imports after stubbing ----
+import importlib
+import ui.schedule_window as schedule_window
+importlib.reload(schedule_window)
+import ui.owner_dashboard as owner_dashboard
+importlib.reload(owner_dashboard)
+
+
+def test_schedule_action_opens_dialog_and_populates_table(monkeypatch):
+    opened = {}
+
+    orig_init = schedule_window.ScheduleWindow.__init__
+    def spy_init(self, *a, **k):
+        orig_init(self, *a, **k)
+        opened['window'] = self
+    monkeypatch.setattr(schedule_window.ScheduleWindow, '__init__', spy_init)
+
+    def fake_exec(self):
+        opened['executed'] = True
+    monkeypatch.setattr(schedule_window.ScheduleWindow, 'exec', fake_exec)
+
+    def fake_init(self, team_id):
+        self.team_id = team_id
+        self.schedule_action = QAction()
+        self.schedule_action.triggered.connect(self.open_schedule_window)
+    monkeypatch.setattr(owner_dashboard.OwnerDashboard, '__init__', fake_init)
+
+    dashboard = owner_dashboard.OwnerDashboard('DRO')
+    dashboard.schedule_action.trigger()
+
+    assert opened.get('executed')
+    window = opened['window']
+    assert window.table.item(0, 0).text() == '2024-04-01'
+    assert window.table.item(0, 1).text() == 'Team A vs Team B'
+

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -34,6 +34,7 @@ from ui.pitchers_window import PitchersWindow
 from ui.transactions_window import TransactionsWindow
 from ui.team_settings_dialog import TeamSettingsDialog
 from ui.standings_window import StandingsWindow
+from ui.schedule_window import ScheduleWindow
 from utils.roster_loader import load_roster, save_roster
 from utils.player_loader import load_players_from_csv
 from utils.news_reader import read_latest_news
@@ -106,8 +107,9 @@ class OwnerDashboard(QWidget):
         settings_action.triggered.connect(self.open_team_settings)
         league_menu = menubar.addMenu("League")
         self.standings_action = league_menu.addAction("Standings")
-        league_menu.addAction("Schedule")
+        self.schedule_action = league_menu.addAction("Schedule")
         self.standings_action.triggered.connect(self.open_standings_window)
+        self.schedule_action.triggered.connect(self.open_schedule_window)
         main.setMenuBar(menubar)
 
         base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -273,6 +275,10 @@ class OwnerDashboard(QWidget):
     def open_standings_window(self):
         """Open the league standings dialog."""
         StandingsWindow(self).exec()
+
+    def open_schedule_window(self):
+        """Open the league schedule dialog."""
+        ScheduleWindow(self).exec()
 
     def open_team_settings(self):
         if not self.team:

--- a/ui/schedule_window.py
+++ b/ui/schedule_window.py
@@ -1,0 +1,41 @@
+from PyQt6.QtWidgets import (
+    QDialog,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+
+class ScheduleWindow(QDialog):
+    """Dialog displaying a simple placeholder schedule."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        try:
+            # Set a descriptive window title if supported by the widget backend
+            self.setWindowTitle("Schedule")
+        except Exception:  # pragma: no cover - stubs without this method
+            pass
+
+        layout = QVBoxLayout(self)
+
+        # Default schedule data used for placeholder view
+        self.schedule_data = [
+            ("2024-04-01", "Team A vs Team B"),
+            ("2024-04-02", "Team C vs Team D"),
+            ("2024-04-03", "Team A at Team C"),
+        ]
+
+        table = QTableWidget()
+        table.setColumnCount(2)
+        table.setRowCount(len(self.schedule_data))
+        table.setHorizontalHeaderLabels(["Date", "Game"])
+        for row, (date, game) in enumerate(self.schedule_data):
+            table.setItem(row, 0, QTableWidgetItem(date))
+            table.setItem(row, 1, QTableWidgetItem(game))
+        table.resizeColumnsToContents()
+
+        # Expose table for tests
+        self.table = table
+        layout.addWidget(table)
+


### PR DESCRIPTION
## Summary
- Implement a new `ScheduleWindow` dialog displaying a placeholder schedule
- Add ability to open `ScheduleWindow` from OwnerDashboard via new `open_schedule_window`
- Include tests ensuring the schedule dialog opens and displays dummy entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bfc427cb4832ebbcaa2aef194987d