### PR TITLE
Add placeholder warnings in schedule and standings windows

### DIFF
--- a/ui/schedule_window.py
+++ b/ui/schedule_window.py
@@ -1,5 +1,6 @@
 from PyQt6.QtWidgets import (
     QDialog,
+    QLabel,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -19,6 +20,10 @@ class ScheduleWindow(QDialog):
 
         layout = QVBoxLayout(self)
 
+        # Using placeholder data
+        layout.addWidget(QLabel("Using placeholder data"))
+
+        # TODO: Replace with real league data
         # Default schedule data used for placeholder view
         self.schedule_data = [
             ("2024-04-01", "Team A vs Team B"),

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -1,5 +1,6 @@
 from PyQt6.QtWidgets import (
     QDialog,
+    QLabel,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -12,10 +13,13 @@ class StandingsWindow(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Standings")
-
         layout = QVBoxLayout(self)
 
+        # Using placeholder data
+        layout.addWidget(QLabel("Using placeholder data"))
+
         table = QTableWidget()
+        # TODO: Replace with real league data
         data = [
             ("Team A", 10, 5),
             ("Team B", 8, 7),


### PR DESCRIPTION
## Summary
- note placeholder data in standings window and mark where real league data should go
- display placeholder notice in schedule window and tag schedule data for future replacement

## Testing
- `pytest tests/test_standings_window.py tests/test_schedule_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689c036f1cf0832e8c4300fe4fae7932