### PR TITLE
Add logging for dialog openings and tests

### DIFF
--- a/tests/test_league_creator.py
+++ b/tests/test_league_creator.py
@@ -8,6 +8,7 @@ import random
 
 
 def test_create_league_generates_files(tmp_path):
+    random.seed(0)
     divisions = {"East": [("CityA", "Cats"), ("CityB", "Dogs")]}
     create_league(str(tmp_path), divisions, "Test League")
 

--- a/tests/test_make_player_item.py
+++ b/tests/test_make_player_item.py
@@ -71,8 +71,11 @@ sys.modules['PyQt6.QtCore'] = qtcore
 sys.modules['PyQt6.QtGui'] = qtgui
 
 # ---- Imports after stubbing ----
+import importlib
 import ui.owner_dashboard as owner_dashboard
+importlib.reload(owner_dashboard)
 import ui.position_players_dialog as pp_dialog
+importlib.reload(pp_dialog)
 from models.pitcher import Pitcher
 from models.player import Player
 
@@ -81,6 +84,8 @@ od_helper = SimpleNamespace(calculate_age=lambda _: 0)
 ppd_helper = SimpleNamespace(_calculate_age=lambda _: 0)
 
 def test_pitcher_uses_pitching_stats_even_if_primary_not_pitcher():
+    owner_dashboard.Qt = qtcore.Qt
+    pp_dialog.Qt = qtcore.Qt
     pitcher = Pitcher(
         player_id='p1', first_name='Pitch', last_name='Er', birthdate='1990-01-01',
         height=72, weight=180, bats='R', primary_position='LF', other_positions=[], gf=10,
@@ -94,6 +99,8 @@ def test_pitcher_uses_pitching_stats_even_if_primary_not_pitcher():
         assert 'CH:' not in text
 
 def test_hitter_uses_hitting_stats_even_if_primary_pitcher():
+    owner_dashboard.Qt = qtcore.Qt
+    pp_dialog.Qt = qtcore.Qt
     hitter = Player(
         player_id='h1', first_name='Hit', last_name='Ter', birthdate='1991-02-02',
         height=70, weight=175, bats='L', primary_position='P', other_positions=[], gf=20,

--- a/tests/test_schedule_window.py
+++ b/tests/test_schedule_window.py
@@ -168,7 +168,7 @@ import ui.owner_dashboard as owner_dashboard
 importlib.reload(owner_dashboard)
 
 
-def test_schedule_action_opens_dialog_and_populates_table(monkeypatch):
+def test_schedule_action_opens_dialog_and_populates_table(monkeypatch, caplog):
     opened = {}
 
     orig_init = schedule_window.ScheduleWindow.__init__
@@ -187,11 +187,13 @@ def test_schedule_action_opens_dialog_and_populates_table(monkeypatch):
         self.schedule_action.triggered.connect(self.open_schedule_window)
     monkeypatch.setattr(owner_dashboard.OwnerDashboard, '__init__', fake_init)
 
-    dashboard = owner_dashboard.OwnerDashboard('DRO')
-    dashboard.schedule_action.trigger()
+    with caplog.at_level("INFO"):
+        dashboard = owner_dashboard.OwnerDashboard('DRO')
+        dashboard.schedule_action.trigger()
 
     assert opened.get('executed')
     window = opened['window']
     assert window.table.item(0, 0).text() == '2024-04-01'
     assert window.table.item(0, 1).text() == 'Team A vs Team B'
+    assert "Schedule window opened" in caplog.text
 

--- a/tests/test_standings_window.py
+++ b/tests/test_standings_window.py
@@ -129,7 +129,11 @@ qtgui.QPixmap = Dummy
 sys.modules['PyQt6.QtGui'] = qtgui
 
 # ---- Imports after stubbing ----
+import importlib
 import ui.owner_dashboard as owner_dashboard
+importlib.reload(owner_dashboard)
+import ui.standings_window as standings_window
+importlib.reload(standings_window)
 
 
 def test_standings_action_opens_dialog(monkeypatch):
@@ -154,3 +158,31 @@ def test_standings_action_opens_dialog(monkeypatch):
     dashboard.standings_action.trigger()
 
     assert opened.get("shown")
+
+
+def test_standings_window_logs_on_init(monkeypatch, caplog):
+    class DummyTable:
+        def __init__(self, *a, **k):
+            pass
+        def setColumnCount(self, n):
+            pass
+        def setRowCount(self, n):
+            pass
+        def setHorizontalHeaderLabels(self, labels):
+            pass
+        def setItem(self, r, c, item):
+            pass
+        def resizeColumnsToContents(self):
+            pass
+
+    class DummyItem:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(standings_window, "QTableWidget", DummyTable)
+    monkeypatch.setattr(standings_window, "QTableWidgetItem", DummyItem)
+    monkeypatch.setattr(standings_window.QDialog, "setWindowTitle", lambda self, *a, **k: None, raising=False)
+
+    with caplog.at_level("INFO"):
+        standings_window.StandingsWindow()
+    assert "Standings window opened" in caplog.text

--- a/ui/admin_dashboard.py
+++ b/ui/admin_dashboard.py
@@ -28,9 +28,12 @@ import csv
 import os
 from logic.league_creator import create_league
 
+from utils.logger import logger
+
 class AdminDashboard(QWidget):
     def __init__(self):
         super().__init__()
+        logger.info("Admin dashboard opened")
         self.setWindowTitle("Admin Dashboard")
         self.setGeometry(200, 200, 500, 300)
 

--- a/ui/exhibition_game_dialog.py
+++ b/ui/exhibition_game_dialog.py
@@ -18,12 +18,15 @@ from logic.simulation import GameSimulation, TeamState, generate_boxscore
 from models.pitcher import Pitcher
 from logic.playbalance_config import PlayBalanceConfig
 
+from utils.logger import logger
+
 
 class ExhibitionGameDialog(QDialog):
     """Dialog to select teams and simulate an exhibition game."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.info("Exhibition game dialog opened")
         self.setWindowTitle("Simulate Exhibition Game")
 
         layout = QVBoxLayout()

--- a/ui/lineup_editor.py
+++ b/ui/lineup_editor.py
@@ -5,10 +5,13 @@ import os
 import csv
 from utils.pitcher_role import get_role
 
+from utils.logger import logger
+
 class LineupEditor(QDialog):
     def __init__(self, team_id):
         self.team_id = team_id
         super().__init__()
+        logger.info("Lineup editor opened")
         self.setWindowTitle("Lineup Editor")
         self.setMinimumSize(900, 600)
 

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -8,6 +8,8 @@ import os
 from ui.admin_dashboard import AdminDashboard
 from ui.owner_dashboard import OwnerDashboard
 
+from utils.logger import logger
+
 # Determine the path to the users file in a cross-platform way
 USER_FILE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "data", "users.txt")
@@ -16,6 +18,7 @@ USER_FILE = os.path.abspath(
 class LoginWindow(QWidget):
     def __init__(self):
         super().__init__()
+        logger.info("Login window opened")
         self.setWindowTitle("UBL Login")
         self.setGeometry(100, 100, 300, 150)
 

--- a/ui/owner_dashboard.py
+++ b/ui/owner_dashboard.py
@@ -42,6 +42,8 @@ from utils.free_agent_finder import find_free_agents
 from utils.team_loader import load_teams, save_team_settings
 from utils.pitcher_role import get_role
 
+from utils.logger import logger
+
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
     """Convert ``#RRGGBB`` or ``#RGB`` strings to an (r, g, b) tuple."""
@@ -69,6 +71,7 @@ class OwnerDashboard(QWidget):
 
     def __init__(self, team_id: str):
         super().__init__()
+        logger.info("Owner dashboard opened")
         self.team_id = team_id
         self.unsaved_changes = False
 

--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -19,12 +19,15 @@ from models.base_player import BasePlayer
 from models.roster import Roster
 from utils.pitcher_role import get_role
 
+from utils.logger import logger
+
 
 class PitchersWindow(QDialog):
     """Display all pitchers grouped by roster level with tabs for roles."""
 
     def __init__(self, players: Dict[str, BasePlayer], roster: Roster, parent=None):
         super().__init__(parent)
+        logger.info("Pitchers window opened")
         self.players = players
         self.roster = roster
 

--- a/ui/pitching_editor.py
+++ b/ui/pitching_editor.py
@@ -3,9 +3,12 @@ import os
 import csv
 from utils.pitcher_role import get_role
 
+from utils.logger import logger
+
 class PitchingEditor(QDialog):
     def __init__(self, team_id):
         super().__init__()
+        logger.info("Pitching editor opened")
         self.team_id = team_id
         self.setWindowTitle("Pitching Staff Editor")
         self.setMinimumSize(500, 500)

--- a/ui/player_profile_dialog.py
+++ b/ui/player_profile_dialog.py
@@ -17,12 +17,15 @@ from PyQt6.QtWidgets import (
 
 from models.base_player import BasePlayer
 
+from utils.logger import logger
+
 
 class PlayerProfileDialog(QDialog):
     """Display basic information, current ratings and stats for a player."""
 
     def __init__(self, player: BasePlayer, parent=None):
         super().__init__(parent)
+        logger.info("Player profile dialog opened")
         self.player = player
         self.setWindowTitle(f"{player.first_name} {player.last_name}")
 

--- a/ui/position_players_dialog.py
+++ b/ui/position_players_dialog.py
@@ -19,6 +19,8 @@ from models.base_player import BasePlayer
 from models.roster import Roster
 from utils.pitcher_role import get_role
 
+from utils.logger import logger
+
 
 class PositionPlayersDialog(QDialog):
     """Display all position players grouped by roster level and position."""
@@ -27,6 +29,7 @@ class PositionPlayersDialog(QDialog):
 
     def __init__(self, players: Dict[str, BasePlayer], roster: Roster, parent=None):
         super().__init__(parent)
+        logger.info("Position players dialog opened")
         self.players = players
         self.roster = roster
 

--- a/ui/schedule_window.py
+++ b/ui/schedule_window.py
@@ -12,12 +12,15 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from utils.logger import logger
+
 
 class ScheduleWindow(QDialog):
     """Dialog displaying a basic placeholder schedule."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.info("Schedule window opened")
 
         # Set the window title if the underlying widget system supports it.
         try:  # pragma: no cover - some test stubs omit this method

--- a/ui/splash_screen.py
+++ b/ui/splash_screen.py
@@ -5,11 +5,14 @@ from PyQt6.QtCore import Qt
 
 from ui.login_window import LoginWindow
 
+from utils.logger import logger
+
 class SplashScreen(QWidget):
     """Initial splash screen displaying the UBL logo and start button."""
 
     def __init__(self):
         super().__init__()
+        logger.info("Splash screen opened")
         self.setWindowTitle("UBL")
 
         layout = QVBoxLayout()

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -6,12 +6,15 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from utils.logger import logger
+
 
 class StandingsWindow(QDialog):
     """Simple dialog displaying dummy league standings."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.info("Standings window opened")
         self.setWindowTitle("Standings")
         layout = QVBoxLayout(self)
 

--- a/ui/team_entry_dialog.py
+++ b/ui/team_entry_dialog.py
@@ -10,12 +10,15 @@ from PyQt6.QtWidgets import (
 
 from logic.team_name_generator import random_team
 
+from utils.logger import logger
+
 
 class TeamEntryDialog(QDialog):
     """Dialog for entering team cities and nicknames."""
 
     def __init__(self, divisions, teams_per_div, parent=None):
         super().__init__(parent)
+        logger.info("Team entry dialog opened")
         self.setWindowTitle("Enter Teams")
         self._inputs = {}
 

--- a/ui/team_settings_dialog.py
+++ b/ui/team_settings_dialog.py
@@ -10,12 +10,15 @@ from PyQt6.QtWidgets import (
 
 from data.ballparks import BALLPARKS
 
+from utils.logger import logger
+
 
 class TeamSettingsDialog(QDialog):
     """Dialog allowing an owner to configure basic team properties."""
 
     def __init__(self, team, parent=None):
         super().__init__(parent)
+        logger.info("Team settings dialog opened")
         self.team = team
         self.setWindowTitle("Team Settings")
 

--- a/ui/transactions_page.py
+++ b/ui/transactions_page.py
@@ -1,11 +1,14 @@
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel
 
+from utils.logger import logger
+
 
 class TransactionsPage(QDialog):
     """Placeholder dialog for team transactions."""
 
     def __init__(self, team_id: str, parent=None):
         super().__init__(parent)
+        logger.info("Transactions page opened")
         self.setWindowTitle("Transactions")
         layout = QVBoxLayout()
         layout.addWidget(QLabel(f"Transactions for {team_id}"))

--- a/ui/transactions_window.py
+++ b/ui/transactions_window.py
@@ -2,12 +2,15 @@
 
 from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout
 
+from utils.logger import logger
+
 
 class TransactionsWindow(QDialog):
     """Simple dialog announcing upcoming transaction tools."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.info("Transactions window opened")
         self.setWindowTitle("Transactions")
 
         layout = QVBoxLayout()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,9 @@
+import logging
+
+logger = logging.getLogger("ubl")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- introduce shared logger utility
- log when each UI dialog or window is opened
- verify logging in schedule and standings window tests
- stabilize league creation test with deterministic seed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca1beb6d0832ea3a2c045a46a422b