### PR TITLE
docs: document UI schedule and standings windows

### DIFF
--- a/ui/schedule_window.py
+++ b/ui/schedule_window.py
@@ -1,8 +1,9 @@
-"""Simple dialog for displaying a placeholder schedule.
+"""Dialog window for displaying the league schedule.
 
-This window is intentionally lightweight: it merely shows a few hard-coded
-games in a table so that the rest of the application can hook into a schedule
-view.  Real schedule data can replace ``schedule_data`` in the future.
+The table is populated with a handful of hard-coded games so that other
+modules (for example, :mod:`ui.owner_dashboard`) have a schedule view to
+interact with. Once a dedicated scheduling service or database is
+available, ``schedule_data`` should be replaced with real information.
 """
 
 from PyQt6.QtWidgets import (
@@ -25,22 +26,27 @@ class ScheduleWindow(QDialog):
         except Exception:  # pragma: no cover - defensive: keep tests happy
             pass
 
+        # Build the main layout for the dialog
         layout = QVBoxLayout(self)
 
-        # TODO: Replace with real league data once available
+        # Placeholder schedule entries
+        # TODO: Replace with data from a scheduling service or database
         self.schedule_data = [
             ("2024-04-01", "Team A vs Team B"),
             ("2024-04-02", "Team C vs Team D"),
             ("2024-04-03", "Team A at Team C"),
         ]
 
-        # Build the table populated with the placeholder schedule
+        # Create the table and populate it with the placeholder schedule
         self.table = QTableWidget(len(self.schedule_data), 2)
         self.table.setHorizontalHeaderLabels(["Date", "Game"])
+
+        # Fill each row with date and matchup information
         for row, (date, game) in enumerate(self.schedule_data):
             self.table.setItem(row, 0, QTableWidgetItem(date))
             self.table.setItem(row, 1, QTableWidgetItem(game))
         self.table.resizeColumnsToContents()
 
+        # Add the populated table to the dialog
         layout.addWidget(self.table)
 

--- a/ui/standings_window.py
+++ b/ui/standings_window.py
@@ -1,3 +1,11 @@
+"""Temporary dialog window for displaying league standings.
+
+The current implementation uses hard-coded data so that other parts of the
+application (for example, :mod:`ui.owner_dashboard`) can open a standings
+view.  Once a proper data source exists, the placeholder values below should
+be replaced with real standings from the services layer or a database.
+"""
+
 from PyQt6.QtWidgets import (
     QDialog,
     QLabel,
@@ -13,25 +21,37 @@ class StandingsWindow(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Standings")
+
+        # Build the vertical layout for the dialog
         layout = QVBoxLayout(self)
 
-        # Using placeholder data
+        # Inform the user that the table uses placeholder values
         layout.addWidget(QLabel("Using placeholder data"))
 
+        # Create the table widget that will show standings
         table = QTableWidget()
-        # TODO: Replace with real league data
+
+        # Placeholder standings data
+        # TODO: Replace with real league data from a standings service
         data = [
             ("Team A", 10, 5),
             ("Team B", 8, 7),
             ("Team C", 7, 8),
             ("Team D", 5, 10),
         ]
+
         table.setColumnCount(3)
         table.setRowCount(len(data))
         table.setHorizontalHeaderLabels(["Team", "Wins", "Losses"])
+
+        # Populate the table with the placeholder data above
         for row, (team, wins, losses) in enumerate(data):
             table.setItem(row, 0, QTableWidgetItem(team))
             table.setItem(row, 1, QTableWidgetItem(str(wins)))
             table.setItem(row, 2, QTableWidgetItem(str(losses)))
+
+        # Ensure columns are sized to fit their contents
         table.resizeColumnsToContents()
+
+        # Add the populated table to the dialog
         layout.addWidget(table)


### PR DESCRIPTION
## Summary
- add module-level docstrings to `ScheduleWindow` and `StandingsWindow`
- annotate major widget creation and data population steps
- restore sample users data modified during tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c992e5fc0832e8f85e8ec2b44ece4