### PR TITLE
Add pre-commit config and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,7 @@ transformers
 torch
 opencv-python
 diskcache
+pre-commit
+black
+flake8
+pytest


### PR DESCRIPTION
## Summary
- add pre-commit configuration with Black, Flake8, and pytest hooks
- run pre-commit in GitHub Actions to execute formatting checks and tests
- include development tools in requirements-dev

## Testing
- `black --check .` *(fails: would reformat 53 files)*
- `flake8 .` *(command not found: flake8)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9146bb64832e810383d9ddff3361