### PR TITLE
Ensure consistent font and sizing for roster dialogs

### DIFF
--- a/ui/pitchers_window.py
+++ b/ui/pitchers_window.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Dict, Iterable
 
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import (
     QDialog,
     QGroupBox,
@@ -29,6 +30,8 @@ class PitchersWindow(QDialog):
         self.roster = roster
 
         self.setWindowTitle("Pitchers")
+        # Use a monospace font so player stats align consistently
+        self.setFont(QFont("Courier New", 9))
 
         layout = QVBoxLayout()
         layout.addWidget(self._build_level_section("Active (ACT)", roster.act))

--- a/ui/transactions_window.py
+++ b/ui/transactions_window.py
@@ -1,5 +1,6 @@
 """Placeholder dialog for future transaction features."""
 
+from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout
 
 
@@ -9,8 +10,14 @@ class TransactionsWindow(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Transactions")
+        # Match font usage with other roster dialogs
+        self.setFont(QFont("Courier New", 9))
 
         layout = QVBoxLayout()
         layout.addWidget(QLabel("Coming soon"))
+        layout.addStretch()
         self.setLayout(layout)
+
+        size = self.sizeHint()
+        self.resize(size.width() * 2, size.height())
 


### PR DESCRIPTION
## Summary
- Apply monospace QFont to Pitchers and Transactions windows
- Add uniform sizeHint-based resize logic and layout stretch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c92827700832ea0fb21c17063d9c8